### PR TITLE
Prototype odd_poeme manuscrit

### DIFF
--- a/besoins_encodage.txt
+++ b/besoins_encodage.txt
@@ -8,10 +8,34 @@ DOSSIER DE PRESSE :
 - balises pour proposer des corrections quand le texte est coupé à cause du collages des articles par exemple
 - balises propres à la mise en page des articles (titre, ligne de séparation, pied de page, en-tête, etc.)
 
+- Pauline: balises pour encoder l'intégralité du dossier de presse dans le même encodage:
+<sourceDoc> contains a transcription or other representation of a single source document potentially forming part of a dossier génétique or collection of sources. 
+
+<group> contains the body of a composite text, grouping together a sequence of distinct texts (or groups of such texts) which are regarded as a unit for some purpose, for example the collected works of an author, a sequence of prose essays, etc.
+
+<floatingText> contains a single text of any kind, whether unitary or composite, which interrupts the text containing it at any point and after which the surrounding text resumes.
 
 POÈMES MANUSCRITS :
 
 =>https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html
+
+STRUCTURATION
+
+Pauline:
+<div>
+@type @n @rhyme
+
+<l> (verse line) contains a single, possibly incomplete, line of verse.
+
+<lg> (line group) contains one or more verse lines functioning as a formal unit, e.g. a stanza, refrain, verse paragraph, etc. 
+Ajouter un @type @n @rhyme
+
+<lb> à n’utiliser que lorsque le retour à la ligne se fait avant la fin d’un vers (car l'élément <l> engage implicitement un changement de ligne dans les pratiques tei)
+
+<rhyme>
+Ajouter un@label
+<rhyme label="A">Harden</rhyme>s and grows <rhyme label="B">cold</rhyme>,</l>
+<l>We cannot cage the <rhyme label="C">minute</rhyme>
 
 - balises de mise en page (ligne de séparation, écriture en colonnes, dans la marge et dans l'interligne)
 
@@ -23,6 +47,35 @@ POÈMES MANUSCRITS :
             @function: utilisation du symbole 
             @rend: forme du symbole
 
+AJOUTS ET CORRECTIONS
+
+Pauline: 
+
+- balises pour décrire plusieurs ajouts réalisés sur le même document encodé:
+<additions>
+Ex: <additions>
+<p>The text of this manuscript is not interpolated with sentences from Royal
+decrees promulgated in 1294, 1305 and 1314. In the margins, however, another
+some what later scribe has added the relevant paragraphs of these decrees, see
+pp. 8, 24, 44, 47 etc.</p>
+<p>As a humorous gesture the scribe in one opening of the manuscript, pp. 36 and
+37, has prolonged the lower stems of one letter f and five letters þ and has
+them drizzle down the margin.</p>
+</additions>
+
+<addSpan> (added span of text) marks the beginning of a longer sequence of text added by an author, scribe.
+
+<choice> groups a number of alternative encodings for the same point in a text.
+
+<corr> (correction) contains the correct form of a passage apparently erroneous in the copy text.
+
+Liste d'attributs utiles:
+@evidence indicates the nature of the evidence supporting the reliability or accuracy of the
+intervention or interpretation.
+@cert (certainty) signifies the degree of certainty associated with the intervention or
+interpretation.
+
+Juliette
 - balises pour indiquer qu'un mot est barré : elles devront pouvoir s'imbriquer entre elles lorsque un même passage est barré à différentes échelles
         <del>:  contains a letter, word, or passage deleted, marked as deleted, or otherwise indicated as superfluous or spurious in the copy text by an author, scribe, or a previous annotator or corrector https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-del.html 
 également delSpan pour une grosse séquence de texte barré https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-delSpan.html
@@ -31,6 +84,9 @@ POÈMES MANUSCRITS :
         <add>: contains letters, words, or phrases inserted in the source text by an author, scribe, or a previous annotator or corrector. https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-add.html
             @place: emplacement de l'ajout (interligne, marge...)
         association <subst> <del> <add>: lorsque le mot a été remplacé par un autre par l'auteur https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHSU
+ 
+Pauline: <delSpan> (deleted span of text) marks the beginning of a longer sequence of text deleted, marked as
+deleted, or otherwise signaled as superfluous or spurious by an author, scribe, annotator, or corrector.
 
 - balise pour indiquer qu'un mot est illisible (souvent lorsqu'il est barré plusieurs fois par l'auteur)
         <gap> indicates a point where material has been omitted in a transcription, whether for editorial reasons described in the TEI header, as part of sampling practice, or because the material is illegible, invisible, or inaudible https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-gap.html
@@ -41,3 +97,20 @@ POÈMES MANUSCRITS :
 - balise pour indiquer lorsqu'un passage a été effacé (dégradation) et devient illisible
         <damage>: contains an area of damage to the text witness https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-damage.html       
             @agent: type de dégradation
+
+SUBSTITUTION ET RESTAURATION
+Pauline:
+<subst> (substitution) groups one or more deletions (or surplus text) with one or more additions when the combination is to be regarded as a single intervention in the text.
+<substJoin> (substitution join) identifies a series of possibly fragmented additions, deletions, or other
+revisions on a manuscript that combine to make up a single intervention in the text.
+<restore> indicates restoration of text to an earlier state by cancellation of an editorial or authorial marking or instruction.
+<supplied> signifies text supplied by the transcriber or editor for any reason; for example because the
+original cannot be read due to physical damage, or because of an obvious omission by the author or
+scribe.
+
+- Pauline: Balises qui indique l'état du document et ses éventuelles dégradations matérielles:
+<supportDesc>
+<condition>
+<p>The manuscript shows signs of damage from water and mould on its
+outermost leaves.</p>
+</condition>

--- a/besoins_encodage.txt
+++ b/besoins_encodage.txt
@@ -11,8 +11,33 @@ DOSSIER DE PRESSE :
 
 POÈMES MANUSCRITS :
 
-- balises pour indiquer qu'un mot est barré : elles devront pouvoir s'imbriquer entre elles lorsque un même passage est barré à différentes échelles
-- balises de mise en page (ligne de séparation, écriture en colonnes, dans la marge et dans l'interligne)
-- balise pour indiquer qu'un mot est illisible (souvent lorsqu'il est barré plusieurs fois par l'auteur)
-- balise pour indiquer lorsqu'un passage a été effacé (dégradation) et devient illisible
+=>https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html
 
+- balises de mise en page (ligne de séparation, écriture en colonnes, dans la marge et dans l'interligne)
+
+    -structuration: https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHFAX
+            _soit imbrication des balises <facsimile> <surface> <zone> pour les colonnes puis <line> pour les lignes
+            _soit utilisation de <pb>, <cb>, <lb> pour encoder la structure en page, colonne et lignes
+    -éléments en dehors du corps de texte:
+        -symboles: <metamark> contains or describes any kind of graphic or written signal within a document the function of which is to determine how it should be read rather than forming part of the actual content of the document. https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-metamark.html
+            @function: utilisation du symbole 
+            @rend: forme du symbole
+
+- balises pour indiquer qu'un mot est barré : elles devront pouvoir s'imbriquer entre elles lorsque un même passage est barré à différentes échelles
+        <del>:  contains a letter, word, or passage deleted, marked as deleted, or otherwise indicated as superfluous or spurious in the copy text by an author, scribe, or a previous annotator or corrector https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-del.html 
+également delSpan pour une grosse séquence de texte barré https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-delSpan.html
+            @rend: type de suppression (barré...)
+            @hand: auteur de la suppression
+        <add>: contains letters, words, or phrases inserted in the source text by an author, scribe, or a previous annotator or corrector. https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-add.html
+            @place: emplacement de l'ajout (interligne, marge...)
+        association <subst> <del> <add>: lorsque le mot a été remplacé par un autre par l'auteur https://www.tei-c.org/release/doc/tei-p5-doc/en/html/PH.html#PHSU
+
+- balise pour indiquer qu'un mot est illisible (souvent lorsqu'il est barré plusieurs fois par l'auteur)
+        <gap> indicates a point where material has been omitted in a transcription, whether for editorial reasons described in the TEI header, as part of sampling practice, or because the material is illegible, invisible, or inaudible https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-gap.html
+            @quantity: éléments non visibles
+            @unit: type d'élément
+            @reason: pourquoi illisibilité
+
+- balise pour indiquer lorsqu'un passage a été effacé (dégradation) et devient illisible
+        <damage>: contains an area of damage to the text witness https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-damage.html       
+            @agent: type de dégradation

--- a/besoins_encodage.txt
+++ b/besoins_encodage.txt
@@ -79,6 +79,7 @@ Juliette
 - balises pour indiquer qu'un mot est barré : elles devront pouvoir s'imbriquer entre elles lorsque un même passage est barré à différentes échelles
         <del>:  contains a letter, word, or passage deleted, marked as deleted, or otherwise indicated as superfluous or spurious in the copy text by an author, scribe, or a previous annotator or corrector https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-del.html 
 également delSpan pour une grosse séquence de texte barré https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-delSpan.html
+
             @rend: type de suppression (barré...)
             @hand: auteur de la suppression
         <add>: contains letters, words, or phrases inserted in the source text by an author, scribe, or a previous annotator or corrector. https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-add.html
@@ -93,6 +94,8 @@ deleted, or otherwise signaled as superfluous or spurious by an author, scribe, 
             @quantity: éléments non visibles
             @unit: type d'élément
             @reason: pourquoi illisibilité
+	    
+Pauline ATTENTION: pour encoder un élément illisible, l'élément <unclear> pour la description des sources primaires semble être préférable que l'élément <gap> en terme de bonne pratique.
 
 - balise pour indiquer lorsqu'un passage a été effacé (dégradation) et devient illisible
         <damage>: contains an area of damage to the text witness https://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-damage.html       

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Title</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+  </teiHeader>
+  <text>
+      <body>
+         <msDesc>
+            <msIdentifier><repository>Bibliothèque nationale de France</repository></msIdentifier>
+            <physDesc>   
+            <objectDesc>
+               <supportDesc>
+               <extent>1 page</extent>        
+               </supportDesc>
+               <layoutDesc>
+                  <layout columns="1">Strophes séparées par un saut de ligne et disposées sur une seule colonne.</layout>
+               </layoutDesc>
+            </objectDesc>
+             </physDesc> 
+         </msDesc>
+         <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+            <head>1909 <add place="beside">88:</add></head>
+            <lg type="quintil" n="1">
+               <l>La dame avait une robe</l>
+               <l>En ottoman violine</l>
+               <l>Et sa tunique brodée d’or</l>
+               <l>Était composée de deux panneaux</l>
+               <l> S’attachant sur l’épaule.</l>
+            </lg>
+            <lg type="quintil" n="2"> 
+               <l>Les yeux dansants comme des anges</l>
+               <l>Elle riait, elle riait</l>
+               <l>Elle avait un visage aux couleurs de France</l>
+               <l>Les yeux bleus, les dents blanches et les lèvres très rouges</l> 
+               <l>Elle avait un visage aux couleurs de France.</l>
+            </lg>
+            <lg type="septain" n="1"> 
+               <l>  Elle était décolletée en rond</l>
+               <l>Et coiffée à la Récamier</l>
+               <l>Avec de beaux bras nus.</l>
+               <l><delSpan spanTo="#l7" extent="4 lines"/>Pareils au col candide</l> 
+               <l>De l’amant divin et ailé</l>
+               <l>De cette Léda solitaire</l>
+               <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
+            </lg>
+            <lg type="monostiche" n="1">
+               <l> - N’entendra-t-on jamais sonner minuit <del><gap extent="1 word" reason="illegible"/></del></l>
+            </lg>
+             <lg type="quatrain" n="1"> 
+                <l>La dame en robe d’ottoman violine</l>
+                <l>Et en tunique brodée d’or</l>
+                <l> Décolletée en rond</l> 
+                <l><subst><add>Promène</add><del>promenait</del></subst> ses boucles</l>
+            </lg>
+            <lg type="quatrain" n="2"> 
+               <l>Son bandeau d’or</l>
+               <l>Et traînant ses petits souliers à boucles</l>
+               <l>Elle était si belle</l> 
+               <l>Que je n’aurais pas osé l’aimer.</l>
+            </lg>
+            <lg type="quintil" n="1">
+               <l>J’aimais les flammes atroces dans les quartiers énormes</l>
+               <l>Où naissaient chaque jour quelques êtres nouveaux</l>
+               <l>Le fer était leur sang, la flamme leur cerveau.</l>
+               <l>J’aimais, j’aimais le peuple habile des machines</l>
+               <l> de luxe et la beauté ne sont que son écume.</l>
+            </lg>
+            <lg type="tercet" n="1">
+               <l>Cette femme était si belle</l>
+               <l>Que je n’aurais pas osé l’aimer (rayé)</l>
+               <l>qu’elle me faisait peur.</l>
+            </lg>
+         </div>
+      </body>
+  </text>
+</TEI>


### PR DESCRIPTION
Bonjour à tous,

Voici une proposition d'encodage-type à partir du poème "1909" pour les versions génétiques des huit premiers poèmes _d'_Alcools__. J'ai utilisé les balises de description des sources primaires pour structurer les données inhérentes aux ajouts, suppressions, substitutions, zones illisibles ainsi qu'à la disposition matérielle du texte. 
Le choix des attributs est à débattre car nous pourrions aller plus loin dans la précision et la granularité. C'est une proposition a minima, une base de travail à extrapoler en fonction de notre objectif commun. Je n'ai pas trouvé opportun d'ajouter un élément handDesc pour la description des écritures car il s'agit toujours de celle d'Apollinaire.

Pensez-vous qu'il serait notamment pertinent d'ajouter des éléments pour l'analyse métrique et prosodique des poèmes (élément rhyme et @label entre autres) ou nous en tenons-nous à la description matérielle et contextuelle de la source?

Merci à tous pour votre avis!