### PR TITLE
Essai Encodage poème Mal-aimé 14r

### DIFF
--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
@@ -48,16 +48,16 @@
                   </figure>
                   <l>Quel chevalier es-tu là bas ?</l>
                   <l><subst>
-                        <del extent="1" unit="word"><gap reason="illegible"/></del>
-                        <add place="above"><del extent="1" unit="word" rend="strikethrough"><gap
+                        <del><gap quantity="1" unit="word" reason="illegible"/></del>
+                     <add place="above"><del rend="strikethrough"><gap quantity="1" unit="word"
                                  reason="illegible"/></del></add>
                         <add rend="overtyped">Sultan</add>
                      </subst> de Turcs puants qui manges</l>
                   <l>Ce que Satan chie aux sabbats</l>
                </lg>
-               <lg type="distique" n="2">
-                  <l><del extent="3" unit="word" rend="strikethrough">Nous n’ain</del></l>
-                  <l><del extent="2" unit="word" rend="strikethrough">Cornu commes</del></l>
+               <lg type="distique" n="1">
+                  <l><del quantity="3" unit="word" rend="strikethrough">Nous n’ain</del></l>
+                  <l><del quantity="2" unit="word" rend="strikethrough">Cornu commes</del></l>
                   <figure rend="align(margin)">
                      <figDesc>Autre accolade regroupant mes deux vers suivants, notés "2" et "1", et
                         avec un nombre barré.</figDesc>
@@ -67,10 +67,10 @@
                   </figure>
                   <l>Cornu comme les mauvais anges</l>
                   <l>Plus criminel que Barrabas</l>
-                  <l><del extent="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
+                  <l><del quantity="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
                </lg>
                <l>Poisson <subst>
-                     <del extent="1" unit="word"><gap reason="illegible"/></del>
+                     <del><gap quantity="1" unit="word" reason="illegible"/></del>
                      <add rend="overtyped">pourri</add>
                   </subst> de Salonique,</l>
                <l>Gemmes de cabochons affreux</l>
@@ -80,29 +80,29 @@
                      <add rend="overtyped">pourri</add>
                   </subst> fit un pet foireux</l>
                <l>Et tu naquis de sa colique</l>
-               <l><del extent="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
-               <lg type="quintil" n="3">
+               <l><del quantity="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
+               <lg type="quintil" n="1">
                   <l>Bourreau de l’Arménie, amant</l>
                   <l>De femmes que des soldats fourent</l>
                   <l>Groin de cochon, cul de jument</l>
-                  <l><del extent="2" unit="word" rend="strikethrough">Tes riches</del></l>
+                  <l><del quantity="2" unit="word" rend="strikethrough">Tes riches</del></l>
                   <l>Tes richesses garde<del rend="strikethrough">nt</del> les toutes</l>
                   <l>Pour payer <subst>
-                        <del extent="1" unit="char">d</del>
+                        <del quantity="1" unit="char">d</del>
                         <add rend="overtyped">t</add>
                      </subst>es médicaments.</l>
                </lg>
             </div>
             <div type="verso" n="48"
                facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f48.item.zoom">
-               <lg type="tercet" n="4">
+               <lg type="tercet" n="2">
                   <figure rend="align(margin)">
                      <figDesc>Accolade indiquant qu'il s'agit d'un morceau du poème du
                         Mal-Aimé</figDesc>
                   </figure>
-                  <l><del extent="6" unit="word" rend="strikethrough">L’amour un jour je l’ai
+                  <l><del quantity="6" unit="word" rend="strikethrough">L’amour un jour je l’ai
                         perdu</del></l>
-                  <l><del extent="6" unit="word" rend="strikethrough">Au fond d’une forêt d’une
+                  <l><del quantity="6" unit="word" rend="strikethrough">Au fond d’une forêt d’une
                         Germaine</del></l>
                   <l>Pour incanter l’amour perdu</l>
                   <l>Le violon à la vie en peine</l>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
@@ -39,7 +39,7 @@
             <div type="recto" n="47" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f21">
                <head>La lettre écrite au sultan par les cosaques zaporogues</head>
                <p><add place="top">14</add></p>
-               <p><add place="top"/>Réponse des cosaques zaporogues au sultan de Constantinople</p>
+		    <p><add place="top">Réponse des cosaques zaporogues au sultan de Constantinople</add></p>
 
                <lg type="tercet" n="1">
                   <figure rend="align(margin)">

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
@@ -76,7 +76,7 @@
                <l>Gemmes de cabochons affreux</l>
                <l>Des yeux creuvés à coup de piques</l>
                <l>Ta <subst>
-                     <del>fi</del>
+                     <del quantity="2" unit="char">fi</del>
                      <add rend="overtyped">pourri</add>
                   </subst> fit un pet foireux</l>
                <l>Et tu naquis de sa colique</l>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Le mal aimé</title>
+            <author>Guillaume Apollinaire</author>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+   </teiHeader>
+   <text>
+      <body>
+         <msDesc>
+            <msIdentifier>
+               <repository>Bibliothèque nationale de France</repository>
+            </msIdentifier>
+            <physDesc>
+               <objectDesc>
+                  <supportDesc>
+                     <extent>2 pages</extent>
+                  </supportDesc>
+                  <layoutDesc>
+                     <layout columns="1">Strophes séparées par un saut de ligne et disposées sur une
+                        seule colonne.</layout>
+                  </layoutDesc>
+               </objectDesc>
+            </physDesc>
+         </msDesc>
+         <div type="poeme">
+            <div type="recto" n="47" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f21">
+               <head>La lettre écrite au sultan par les cosaques zaporogues</head>
+               <p><add place="top">14</add></p>
+               <p><add place="top"/>Réponse des cosaques zaporogues au sultan de Constantinople</p>
+
+               <lg type="tercet" n="1">
+                  <figure rend="align(margin)">
+                     <figDesc>Accolade regroupant les trois vers notée "2" puis corrigée en
+                        "3".</figDesc>
+                  </figure>
+                  <l>Quel chevalier es-tu là bas ?</l>
+                  <l><subst>
+                        <del extent="1" unit="word"><gap reason="illegible"/></del>
+                        <add place="above"><del extent="1" unit="word" rend="strikethrough"><gap
+                                 reason="illegible"/></del></add>
+                        <add rend="overtyped">Sultan</add>
+                     </subst> de Turcs puants qui manges</l>
+                  <l>Ce que Satan chie aux sabbats</l>
+               </lg>
+               <lg type="distique" n="2">
+                  <l><del extent="3" unit="word" rend="strikethrough">Nous n’ain</del></l>
+                  <l><del extent="2" unit="word" rend="strikethrough">Cornu commes</del></l>
+                  <figure rend="align(margin)">
+                     <figDesc>Autre accolade regroupant mes deux vers suivants, notés "2" et "1", et
+                        avec un nombre barré.</figDesc>
+                  </figure>
+                  <figure rend="align(center)">
+                     <figDesc>Tampon sur lequel on lit "Bibliothèque nationale MSS.</figDesc>
+                  </figure>
+                  <l>Cornu comme les mauvais anges</l>
+                  <l>Plus criminel que Barrabas</l>
+                  <l><del extent="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
+               </lg>
+               <l>Poisson <subst>
+                     <del extent="1" unit="word"><gap reason="illegible"/></del>
+                     <add rend="overtyped">pourri</add>
+                  </subst> de Salonique,</l>
+               <l>Gemmes de cabochons affreux</l>
+               <l>Des yeux creuvés à coup de piques</l>
+               <l>Ta <subst>
+                     <del>fi</del>
+                     <add rend="overtyped">pourri</add>
+                  </subst> fit un pet foireux</l>
+               <l>Et tu naquis de sa colique</l>
+               <l><del extent="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
+               <lg type="quintil" n="3">
+                  <l>Bourreau de l’Arménie, amant</l>
+                  <l>De femmes que des soldats fourent</l>
+                  <l>Groin de cochon, cul de jument</l>
+                  <l><del extent="2" unit="word" rend="strikethrough">Tes riches</del></l>
+                  <l>Tes richesses garde<del rend="strikethrough">nt</del> les toutes</l>
+                  <l>Pour payer <subst>
+                        <del extent="1" unit="char">d</del>
+                        <add rend="overtyped">t</add>
+                     </subst>es médicaments.</l>
+               </lg>
+            </div>
+            <div type="verso" n="48"
+               facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f48.item.zoom">
+               <lg type="tercet" n="4">
+                  <figure rend="align(margin)">
+                     <figDesc>Accolade indiquant qu'il s'agit d'un morceau du poème du
+                        Mal-Aimé</figDesc>
+                  </figure>
+                  <l><del extent="6" unit="word" rend="strikethrough">L’amour un jour je l’ai
+                        perdu</del></l>
+                  <l><del extent="6" unit="word" rend="strikethrough">Au fond d’une forêt d’une
+                        Germaine</del></l>
+                  <l>Pour incanter l’amour perdu</l>
+                  <l>Le violon à la vie en peine</l>
+                  <l>Et à cordes de pendus</l>
+               </lg>
+            </div>
+         </div>
+      </body>
+   </text>
+</TEI>


### PR DESCRIPTION
Vue : https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f47.item

Voici un essai d'encodage sur deux feuillets assez complexes.

Posent encore problème : 

- le tampon au milieu (je crois que l'on a décidé de quoi faire pour le dossier de presse dans le cas d'une estampille qui revenait systématiquement mais pas pour les poèmes manuscrits ; j'en ai rendu compte juste par un `<figure>`)

- l'attribut `@rend` utilisé dans `<figure>` équivalant à `@place` dans `<add>`

J'ai choisi volontairement un feuillet complexe pour voir les limites : ça a l'air de fonctionner, mais je précise que je n'ai rien mis dans l'attribut `@rend` d'un `<del>` lorsque je renseigne le mot par lequel le mot supprimé est remplacé avec la balise `<add>` qui suit dans le cas d'une substitution (attribut `@rend="overtyped"`).

Enfin, est-il utile de préciser la quantité des suppressions lisibles ? ou gardons-nous uniquement ces précisions pour la balise `<gap>` ou `<del>` lorsque l'on ne lit pas le mot supprimé ?

Je vous mets le code qui nous intéresse directement ici aussi :

```
<div type="poeme">
            <div type="recto" n="47" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f21">
               <head>La lettre écrite au sultan par les cosaques zaporogues</head>
               <p><add place="top">14</add></p>
               <p><add place="top"/>Réponse des cosaques zaporogues au sultan de Constantinople</p>

               <lg type="tercet" n="1">
                  <figure rend="align(margin)">
                     <figDesc>Accolade regroupant les trois vers notée "2" puis corrigée en
                        "3".</figDesc>
                  </figure>
                  <l>Quel chevalier es-tu là bas ?</l>
                  <l><subst>
                        <del extent="1" unit="word"><gap reason="illegible"/></del>
                        <add place="above"><del extent="1" unit="word" rend="strikethrough"><gap
                                 reason="illegible"/></del></add>
                        <add rend="overtyped">Sultan</add>
                     </subst> de Turcs puants qui manges</l>
                  <l>Ce que Satan chie aux sabbats</l>
               </lg>
               <lg type="distique" n="2">
                  <l><del extent="3" unit="word" rend="strikethrough">Nous n’ain</del></l>
                  <l><del extent="2" unit="word" rend="strikethrough">Cornu commes</del></l>
                  <figure rend="align(margin)">
                     <figDesc>Autre accolade regroupant mes deux vers suivants, notés "2" et "1", et
                        avec un nombre barré.</figDesc>
                  </figure>
                  <figure rend="align(center)">
                     <figDesc>Tampon sur lequel on lit "Bibliothèque nationale MSS.</figDesc>
                  </figure>
                  <l>Cornu comme les mauvais anges</l>
                  <l>Plus criminel que Barrabas</l>
                  <l><del extent="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
               </lg>
               <l>Poisson <subst>
                     <del extent="1" unit="word"><gap reason="illegible"/></del>
                     <add rend="overtyped">pourri</add>
                  </subst> de Salonique,</l>
               <l>Gemmes de cabochons affreux</l>
               <l>Des yeux creuvés à coup de piques</l>
               <l>Ta <subst>
                     <del>fi</del>
                     <add rend="overtyped">pourri</add>
                  </subst> fit un pet foireux</l>
               <l>Et tu naquis de sa colique</l>
               <l><del extent="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
               <lg type="quintil" n="3">
                  <l>Bourreau de l’Arménie, amant</l>
                  <l>De femmes que des soldats fourent</l>
                  <l>Groin de cochon, cul de jument</l>
                  <l><del extent="2" unit="word" rend="strikethrough">Tes riches</del></l>
                  <l>Tes richesses garde<del rend="strikethrough">nt</del> les toutes</l>
                  <l>Pour payer <subst>
                        <del extent="1" unit="char">d</del>
                        <add rend="overtyped">t</add>
                     </subst>es médicaments.</l>
               </lg>
            </div>
            <div type="verso" n="48"
               facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f48.item.zoom">
               <lg type="tercet" n="4">
                  <figure rend="align(margin)">
                     <figDesc>Accolade indiquant qu'il s'agit d'un morceau du poème du
                        Mal-Aimé</figDesc>
                  </figure>
                  <l><del extent="6" unit="word" rend="strikethrough">L’amour un jour je l’ai
                        perdu</del></l>
                  <l><del extent="6" unit="word" rend="strikethrough">Au fond d’une forêt d’une
                        Germaine</del></l>
                  <l>Pour incanter l’amour perdu</l>
                  <l>Le violon à la vie en peine</l>
                  <l>Et à cordes de pendus</l>
               </lg>
            </div>
         </div>
```