### PR TITLE
Exemple d'encodage des versions génétiques avec l'élément Group

### DIFF
--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/ExempleElementGroup.VersionGenetique.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/ExempleElementGroup.VersionGenetique.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+  <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Title</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+  </teiHeader>
+  <text>
+     <front>
+        <docTitle>
+           <titlePart>Apollinaire</titlePart>
+           <titlePart>Sept poèmes d'Alcools</titlePart>
+        </docTitle>
+     </front>
+     <group>
+        <text>
+           <front>
+              <head rend="align(top)">Sept poèmes d'Alcools</head>
+              <docTitle>
+                 <titlePart>Les Cloches</titlePart>
+                 <titlePart>Manuscrit autographe</titlePart>
+              </docTitle>
+           </front>
+           <body>
+              <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+                 <head>Les Cloches</head>
+                 <lg type="quintil" n="1">
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                 </lg> 
+              </div>
+           </body>
+        </text>
+      <text>
+         <front>
+            <head rend="align(top)">Sept poèmes d'Alcools</head>
+            <docTitle>
+               <titlePart>1909</titlePart>
+               <titlePart>Manuscrit autographie</titlePart>
+            </docTitle>
+         </front>
+      <body>
+         <msDesc>
+            <msIdentifier><repository>Bibliothèque nationale de France</repository></msIdentifier>
+            <physDesc>   
+            <objectDesc>
+               <supportDesc>
+               <extent>1 page</extent>        
+               </supportDesc>
+               <layoutDesc>
+                  <layout columns="1">Strophes séparées par un saut de ligne et disposées sur une seule colonne.</layout>
+               </layoutDesc>
+            </objectDesc>
+             </physDesc> 
+         </msDesc>
+         <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+            <head>1909 <add place="beside">88:</add></head>
+            <lg type="quintil" n="1">
+               <l>La dame avait une robe</l>
+               <l>En ottoman violine</l>
+               <l>Et sa tunique brodée d’or</l>
+               <l>Était composée de deux panneaux</l>
+               <l> S’attachant sur l’épaule.</l>
+            </lg>
+            <lg type="quintil" n="2"> 
+               <l>Les yeux dansants comme des anges</l>
+               <l>Elle riait, elle riait</l>
+               <l>Elle avait un visage aux couleurs de France</l>
+               <l>Les yeux bleus, les dents blanches et les lèvres très rouges</l> 
+               <l>Elle avait un visage aux couleurs de France.</l>
+            </lg>
+            <lg type="septain" n="1"> 
+               <l>  Elle était décolletée en rond</l>
+               <l>Et coiffée à la Récamier</l>
+               <l>Avec de beaux bras nus.</l>
+               <l><delSpan spanTo="#l7" quantity="4" unit="lines"/>Pareils au col candide</l> 
+               <l>De l’amant divin et ailé</l>
+               <l>De cette Léda solitaire</l>
+               <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
+            </lg>
+            <lg type="monostiche" n="1">
+               <l> - N’entendra-t-on jamais sonner minuit <del><gap quantity="1" unit="word" reason="illegible"/></del></l>
+            </lg>
+             <lg type="quatrain" n="1"> 
+                <l>La dame en robe d’ottoman violine</l>
+                <l>Et en tunique brodée d’or</l>
+                <l> Décolletée en rond</l> 
+                <l><subst><add>Promène</add><del>promenait</del></subst> ses boucles</l>
+            </lg>
+            <lg type="quatrain" n="2"> 
+               <l>Son bandeau d’or</l>
+               <l>Et traînant ses petits souliers à boucles</l>
+               <l>Elle était si belle</l> 
+               <l>Que je n’aurais pas osé l’aimer.</l>
+            </lg>
+            <lg type="quintil" n="1">
+               <l>J’aimais les flammes atroces dans les quartiers énormes</l>
+               <l>Où naissaient chaque jour quelques êtres nouveaux</l>
+               <l>Le fer était leur sang, la flamme leur cerveau.</l>
+               <l>J’aimais, j’aimais le peuple habile des machines</l>
+               <l> de luxe et la beauté ne sont que son écume.</l>
+            </lg>
+            <lg type="tercet" n="1">
+               <l>Cette femme était si belle</l>
+               <l>Que je n’aurais pas osé l’aimer (rayé)</l>
+               <l>qu’elle me faisait peur.</l>
+            </lg>
+         </div>
+      </body>
+      </text>
+     </group>
+  </text>
+</TEI>


### PR DESCRIPTION
Bonjour à tous,

Voici un exemple d'encodage que j'ai réalisé à partir d'un extrait du recueil de versions génétiques de _Sept Poèmes d'Alcools _d'Apollinaire. L'objectif est de vous montrer la structure générale et les modalités d'insertion de chaque poème dans l'ensemble contenu par l'élément "group".
C'est pourquoi je n'ai pas développé l'encodage du premier poème mentionné, l'idée étant simplement de vous offrir une vue de l'arborescence et l'intégration des éléments de description et d'en-tête dans les sous-ensembles. Je pense que c'est le meilleur moyen de respecter l'intégrité des données de notre source, laquelle regroupe plusieurs textes distincts réunis dans la même unité documentaire. 
Je pense que nous pouvons déterminer à partir de cet exemple nos besoins en terme d'attributs obligatoires et optionnels pour les éléments contenus dans chaque "front" (sorte de header pour chaque poème).