### PR TITLE
Corrections et normalisation des prototypes d'encodage

### DIFF
--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
@@ -32,13 +32,14 @@
              </physDesc> 
          </msDesc>
          <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
-            <head>1909 <add place="beside">88:</add></head>
+            <head>1909 <add place="beside">88</add></head>
+		 <p><add place="top">18</add></p>
             <lg type="quintil" n="1">
                <l>La dame avait une robe</l>
                <l>En ottoman violine</l>
                <l>Et sa tunique brodée d’or</l>
                <l>Était composée de deux panneaux</l>
-               <l> S’attachant sur l’épaule.</l>
+               <l>S’attachant sur l’épaule.</l>
             </lg>
             <lg type="quintil" n="2"> 
                <l>Les yeux dansants comme des anges</l>
@@ -48,22 +49,25 @@
                <l>Elle avait un visage aux couleurs de France.</l>
             </lg>
             <lg type="septain" n="1"> 
-               <l>  Elle était décolletée en rond</l>
+               <l>Elle était décolletée en rond</l>
                <l>Et coiffée à la Récamier</l>
                <l>Avec de beaux bras nus.</l>
-               <l><delSpan spanTo="#l7" quantity="4" unit="line"/>Pareils au col candide</l> 
+               <l><delSpan spanTo="#l7" quantity="4" unit="line" rend="strikethrough"/>Pareils au col candide</l> 
                <l>De l’amant divin et ailé</l>
                <l>De cette Léda solitaire</l>
                <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
             </lg>
             <lg type="monostiche" n="1">
-               <l> - N’entendra-t-on jamais sonner minuit <del><gap quantity="1" unit="word" reason="illegible"/></del></l>
+               <l> - N’entendra-t-on jamais sonner minuit <del rend="strikethrough"><gap quantity="1" unit="word" reason="illegible"/></del></figure>
+                  <figure rend="align(center)">
+                     <figDesc>Tampon de la BnF</figDesc>
+                  </figure></l>
             </lg>
              <lg type="quatrain" n="1"> 
                 <l>La dame en robe d’ottoman violine</l>
                 <l>Et en tunique brodée d’or</l>
-                <l> Décolletée en rond</l> 
-                <l><subst><add>Promène</add><del>promenait</del></subst> ses boucles</l>
+                <l>Décolletée en rond</l> 
+                <l><subst><del quantity="3" unit="char" rend="overtyped">promenait</del><add>Promène</add></subst> ses boucles</l>
             </lg>
             <lg type="quatrain" n="2"> 
                <l>Son bandeau d’or</l>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
@@ -31,7 +31,7 @@
             </objectDesc>
              </physDesc> 
          </msDesc>
-         <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+         <div type="poeme" n="63" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
             <head>1909 <add place="beside">88</add></head>
 		 <p><add place="top">18</add></p>
             <lg type="quintil" n="1">

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
@@ -51,13 +51,13 @@
                <l>  Elle était décolletée en rond</l>
                <l>Et coiffée à la Récamier</l>
                <l>Avec de beaux bras nus.</l>
-               <l><delSpan spanTo="#l7" extent="4 lines"/>Pareils au col candide</l> 
+               <l><delSpan spanTo="#l7" quantity="4" unit="line"/>Pareils au col candide</l> 
                <l>De l’amant divin et ailé</l>
                <l>De cette Léda solitaire</l>
                <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
             </lg>
             <lg type="monostiche" n="1">
-               <l> - N’entendra-t-on jamais sonner minuit <del><gap extent="1 word" reason="illegible"/></del></l>
+               <l> - N’entendra-t-on jamais sonner minuit <del><gap quantity="1" unit="word" reason="illegible"/></del></l>
             </lg>
              <lg type="quatrain" n="1"> 
                 <l>La dame en robe d’ottoman violine</l>
@@ -80,7 +80,7 @@
             </lg>
             <lg type="tercet" n="1">
                <l>Cette femme était si belle</l>
-               <l>Que je n’aurais pas osé l’aimer (rayé)</l>
+               <l><del quantity="1" unit="line" rend="strikethrough">Que je n’aurais pas osé l’aimer</del></l>
                <l>qu’elle me faisait peur.</l>
             </lg>
          </div>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
@@ -58,10 +58,7 @@
                <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
             </lg>
             <lg type="monostiche" n="1">
-               <l> - N’entendra-t-on jamais sonner minuit <del rend="strikethrough"><gap quantity="1" unit="word" reason="illegible"/></del></figure>
-                  <figure rend="align(center)">
-                     <figDesc>Tampon de la BnF</figDesc>
-                  </figure></l>
+               <l> - N’entendra-t-on jamais sonner minuit <del rend="strikethrough"><gap quantity="1" unit="word" reason="illegible"/></del>
             </lg>
              <lg type="quatrain" n="1"> 
                 <l>La dame en robe d’ottoman violine</l>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_1909.xml
@@ -58,7 +58,7 @@
                <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
             </lg>
             <lg type="monostiche" n="1">
-               <l> - N’entendra-t-on jamais sonner minuit <del rend="strikethrough"><gap quantity="1" unit="word" reason="illegible"/></del>
+               <l> - N’entendra-t-on jamais sonner minuit <del rend="strikethrough"><gap quantity="1" unit="word" reason="illegible"/></del></l>
             </lg>
              <lg type="quatrain" n="1"> 
                 <l>La dame en robe d’ottoman violine</l>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_malaime_4r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_malaime_4r.xml
@@ -35,54 +35,68 @@
                     </objectDesc>
                 </physDesc>
             </msDesc>
-            <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f21">
+            <div type="poeme">
                 <head>La chanson du mal aimé</head>
-                <pb n="4" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f25"/>
-                <figure place="top left" rend="gribouilli"/>
-                <p><add place="top right">4</add></p>
-                <lg type="quintil" n="1">
-                    <l>Adieu, faux Amour qui t’éloignes </l>
-                    <l>
-                        <del>
-                            <gap extent="3" unit="word" reason="illegible"/>
-                        </del> je l’ai perdue</l>
-                    <l><del><unclear reason="illegible">Da</unclear></del>ns une forêt
-                                d’Allema<del><unclear reason="illegible">gne</unclear></del></l>
-                    <l>
-                        <del><gap extent="1" unit="word" reason="illegible"/></del>gît sanglant, le
-                        cou <del><gap extent="1" unit="word" reason="illegible"/></del></l>
-                    <l><unclear>D</unclear>errière les sept montagnes</l> <figure place="left" rend="gribouilli"/>
-                </lg>
+                <div type="recto" n="4" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f25">
+                    <figure place="align(top left)">
+                        <figDesc>Grande rature ronde</figDesc>
+                    </figure>
+                    <p><add place="top right">4</add></p>
+                    <lg type="quintil" n="1">
+                        <l>Adieu, faux Amour qui t’éloignes </l>
+                        <l>
+                            <del>
+                                <gap quantity="3" unit="word" reason="illegible"/>
+                            </del> je l’ai perdue</l>
+                        <l><del><unclear reason="illegible">Da</unclear></del>ns une forêt
+                                    d’Allema<del><unclear reason="illegible">gne</unclear></del></l>
+                        <l>
+                            <del><gap quantity="1" unit="word" reason="illegible"/></del>gît
+                            sanglant, le cou <del><gap quantity="1" unit="word" reason="illegible"
+                                /></del></l>
+                        <l><unclear>D</unclear>errière les sept montagnes</l>
+                        <figure rend="align(left)">
+                            <figDesc>Points alignés horizontalement</figDesc>
+                        </figure>
+                    </lg>
 
-                <lg type="quintil" n="2">
-                    <l><del><unclear>V</unclear></del>ous qui aimez, vous n’avez</l>
+                    <lg type="quintil" n="2">
+                        <l><del><unclear>V</unclear></del>ous qui aimez, vous n’avez</l>
 
-                    <l><subst>
-                            <del rend="line">Connu d’Amour de cette sor<unclear>te</unclear></del>
-                            <add place="above"> vu, couché dans les feuilles m<unclear>ortes</unclear></add>
-                        </subst></l>
-                    <l><subst>
-                            <del rend="line">D’Amour aime jusqu’au t<unclear>répas</unclear></del>
-                            <add place="above">Mon <del rend="line">pauvre</del> Amour après son
-                                trépas</add>
-                        </subst></l> <metamark place="left" rend="tampon"/>
-                    <l>
-                        <del><gap extent="1" unit="word" reason="illegible"/></del> coeurs bougent
-                                <del><gap extent="1" unit="word" reason="illegible"/></del>
-                        portes,</l>
-                    <l> Vous n’aimez p<unclear>a</unclear>s, vou<unclear>s</unclear> n'<unclear>aim</unclear>ez pas…</l>
-                </lg>
+                        <l><subst>
+                                <del>Connu d’Amour de cette sor<unclear>te</unclear></del>
+                                <add rend="overtyped"> vu, couché dans les feuilles
+                                        m<unclear>ortes</unclear></add>
+                            </subst></l>
+                        <l><subst>
+                                <del>D’Amour aime jusqu’au t<unclear>répas</unclear></del>
+                                <add rend="overtyped">Mon <del quantity="1" unit="word"
+                                        rend="strikethrough">pauvre</del> Amour après son
+                                    trépas</add>
+                            </subst></l>
+                        <metamark place="left" rend="tampon"/>
+                        <l>
+                            <del><gap quantity="1" unit="word" reason="illegible"/></del> coeurs
+                            bougent <del><gap quantity="1" unit="word" reason="illegible"/></del>
+                            portes,</l>
+                        <l> Vous n’aimez p<unclear>a</unclear>s, vou<unclear>s</unclear>
+                                n'<unclear>aim</unclear>ez pas…</l>
+                    </lg>
 
-                <lg type="septain" n="1">
-                    <l>Voie lactée ô sœur lumineuse</l>
-                    <l>Des blancs ruisseaux de Chanaan</l>
-                    <pb n="4bis" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f26"/>
-                    <l>Je me souviens d’une autre année,</l>
-                    <l>C’était l’aube d’un jour d’avril.</l>
-                    <l>J’ai chanté ma joie bien-aimée,</l>
-                    <l>Chanté l’amour à voix virile,</l>
-                    <l> Au moment d’amour de l’année.</l>
-                </lg>
+                    <lg type="septain" n="1" part="I">
+                        <l>Voie lactée ô sœur lumineuse</l>
+                        <l>Des blancs ruisseaux de Chanaan</l>
+                    </lg>
+                </div>
+                <div type="verso" n="5" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f26">
+                    <lg type="septain" n="1" part="F">
+                        <l>Je me souviens d’une autre année,</l>
+                        <l>C’était l’aube d’un jour d’avril.</l>
+                        <l>J’ai chanté ma joie bien-aimée,</l>
+                        <l>Chanté l’amour à voix virile,</l>
+                        <l> Au moment d’amour de l’année.</l>
+                    </lg>
+                </div>
             </div>
         </body>
     </text>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_malaime_4r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/Poeme_malaime_4r.xml
@@ -36,7 +36,7 @@
                 </physDesc>
             </msDesc>
             <div type="poeme">
-                <head>La chanson du mal aimé</head>
+                <head>La chanson du Mal aimé</head>
                 <div type="recto" n="4" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f25">
                     <figure place="align(top left)">
                         <figDesc>Grande rature ronde</figDesc>
@@ -64,17 +64,16 @@
                         <l><del><unclear>V</unclear></del>ous qui aimez, vous n’avez</l>
 
                         <l><subst>
-                                <del>Connu d’Amour de cette sor<unclear>te</unclear></del>
-                                <add rend="overtyped"> vu, couché dans les feuilles
+                                <del quantity="6" unit="word" rend="overtyped">Connu d’Amour de cette sor<unclear>te</unclear></del>
+                                <add> vu, couché dans les feuilles
                                         m<unclear>ortes</unclear></add>
                             </subst></l>
                         <l><subst>
-                                <del>D’Amour aime jusqu’au t<unclear>répas</unclear></del>
-                                <add rend="overtyped">Mon <del quantity="1" unit="word"
+                                <del quantity="4" unit="word" rend="overtyped">D’Amour aime jusqu’au t<unclear>répas</unclear></del>
+                                <add>Mon <del quantity="1" unit="word"
                                         rend="strikethrough">pauvre</del> Amour après son
                                     trépas</add>
                             </subst></l>
-                        <metamark place="left" rend="tampon"/>
                         <l>
                             <del><gap quantity="1" unit="word" reason="illegible"/></del> coeurs
                             bougent <del><gap quantity="1" unit="word" reason="illegible"/></del>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/poeme_malaime_14r.xml
@@ -62,22 +62,19 @@
                      <figDesc>Autre accolade regroupant mes deux vers suivants, notés "2" et "1", et
                         avec un nombre barré.</figDesc>
                   </figure>
-                  <figure rend="align(center)">
-                     <figDesc>Tampon sur lequel on lit "Bibliothèque nationale MSS.</figDesc>
-                  </figure>
                   <l>Cornu comme les mauvais anges</l>
                   <l>Plus criminel que Barrabas</l>
                   <l><del quantity="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
                </lg>
                <l>Poisson <subst>
-                     <del><gap quantity="1" unit="word" reason="illegible"/></del>
-                     <add rend="overtyped">pourri</add>
+                     <del rend="overtyped"><gap quantity="1" unit="word" reason="illegible"/></del>
+                     <add>pourri</add>
                   </subst> de Salonique,</l>
                <l>Gemmes de cabochons affreux</l>
                <l>Des yeux creuvés à coup de piques</l>
                <l>Ta <subst>
-                     <del quantity="2" unit="char">fi</del>
-                     <add rend="overtyped">pourri</add>
+                     <del quantity="2" unit="char" rend="overtyped">fi</del>
+                     <add>pourri</add>
                   </subst> fit un pet foireux</l>
                <l>Et tu naquis de sa colique</l>
                <l><del quantity="3" unit="word" rend="strikethrough">Ne réponds rien</del></l>
@@ -88,8 +85,8 @@
                   <l><del quantity="2" unit="word" rend="strikethrough">Tes riches</del></l>
                   <l>Tes richesses garde<del rend="strikethrough">nt</del> les toutes</l>
                   <l>Pour payer <subst>
-                        <del quantity="1" unit="char">d</del>
-                        <add rend="overtyped">t</add>
+                        <del quantity="1" unit="char" rend="overtyped">d</del>
+                        <add>t</add>
                      </subst>es médicaments.</l>
                </lg>
             </div>


### PR DESCRIPTION
Bonjour à tous, 

Je viens de réaliser des corrections sur nos prototypes d'encodage suite à la clôture de nos issues #35 #36 #37 #39. Elles concernent donc les éléments `<del> <add> <gap> <figure>`. 
J'ai également corrigé la structure du fichier mal_aime_4r, en supprimant la balise `<pb>`, qui ne correspondait pas à l'utilisation proposée dans les issues #33 et #34.

N'hésitez pas à modifier ce qui a été fait sur cette branche si vous voyez des oublis!