### PR TITLE
Exemple encodage d'articles du dossier de presse avec l'élément Group

### DIFF
--- a/dossierdepresse/encodage_element_group_dp_articles/dp_articles_group.xml
+++ b/dossierdepresse/encodage_element_group_dp_articles/dp_articles_group.xml
@@ -1,0 +1,1056 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Title</title>
+         </titleStmt>
+         <publicationStmt>
+            <p>Publication Information</p>
+         </publicationStmt>
+         <sourceDesc>
+            <p>Information about the source</p>
+         </sourceDesc>
+      </fileDesc>
+   </teiHeader>
+   <text>
+      <front>
+         <docTitle facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f145.item.r=Apollinaire%20manuscrits.zoom">
+            <titlePart>Apollinaire. Répertoire alphabétique utilisé pour confectionner le dossier de
+               presse de l'Hérésiarque, Alcools, l'Enfer de la Bibliothèque nationale et Le
+               Manifeste de l'Antitradition futuriste.</titlePart>
+         </docTitle>
+         <docAuthor>Guillaume Apollinaire</docAuthor>
+      </front>
+      <group>
+         <text>
+            <body>
+               <div type="article" n="157, 158, 159, 160, 161, 163, 164" xml:id="article_157-161_161-164"
+                  xml:lang="fr">
+                  <pb
+                     facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f157.item.r=Apollinaire%20manuscrits"/>
+                  
+                  <head>A Guillaume Apollinaire <lb/> prose rythmée pour chanter ses vers.</head>
+                  
+                  <div>
+                     <head rend="center">I</head>
+                     <lg>
+                        <l>Au paradis des lyres,</l>
+                        <l>Sous les fumées et griseries</l>
+                        <l>De sublimes <ref target="#alcools">« Alcools »</ref>,</l>
+                        <l>Par devant le Concile Vatidique</l>
+                        <l>Des Élus aux fronts de gloire</l>
+                        <l>Qui se tient et se perpétue</l>
+                        <l>Dans la reconnaissante mémoire</l>
+                        <l>Des cerveaux dignes d‘aimer les vers ;</l>
+                        <l>De rares Héros persistent aux sommet des siècles.</l>
+                        <l>Quelques—uns y figurent</l>
+                        <l>En dieux orphiques ou séraphiques musiciens,</l>
+                        <l>D‘aucuns, soit en rhéteurs, soit en pontifes,</l>
+                        <l>En élégiaques, en pleureurs, en tragiques,</l>
+                        <l>En rieurs ou libertins,</l>
+                        <l>Certains en troubadours et d‘autres en bouffons ;</l>
+                        <l>Mais, juste au centre de ce Concile d‘apothéose</l>
+                        <l>Et briguant Phonneur qu‘on l‘agrée</l>
+                        <l>Parmi cette impérissable famille,</l>
+                        <l>Face aux poètes émerveillés,</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur.</l>
+                     </lg>
+                  </div>
+                  
+                  <div>
+                     <head rend="center">II</head>
+                     <lg>
+                        <l>Expert en l‘art de distiller</l>
+                        <l>L‘enivrante folie</l>
+                        <l>Des corrosifs de choix ou de fantaisie</l>
+                        <l>Il crée d‘hallucinantes chorégraphies</l>
+                        <l>Qui rappellent les contorsions, pandiculations</l>
+                        <l>Et baillements macabres</l>
+                        <l>Des Lucifériennes goéties.</l>
+                        <note><ref target="#la_phalange">La Phalange</ref></note>
+                        
+                        <pb
+                           facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f158.item.r=Apollinaire%20manuscrits"/>
+                        
+                        <l>Puis virtuose du pas de quatre</l>
+                        <l>Du cavalier seul</l>
+                        <l>Et de la mesure classique ;</l>
+                        <l>Il tricote des jarrets,</l>
+                        <l>Gavotte sur deux temps à la française,</l>
+                        <l>Valse sur trois à la viennoise,</l>
+                        <l>Fait des ronds de jambe,</l>
+                        <l>Se campe, se cambre,</l>
+                        <l>Se dandine, s‘étire</l>
+                        <l>Et, soudain, en ascension,</l>
+                        <l>Comme Apollonius de Tyane dans Ephèse</l>
+                        <l>Il reste en l'air, y oscille et vire,</l>
+                        <l>Sorte de lampe diaphane,</l>
+                        <l>Et pareil à cette chrysalide</l>
+                        <l>Que suspend aux branches hautes</l>
+                        <l>La chenille dite : Vanesse du grand Paon du Jour,</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur.</l>
+                     </lg>
+                  </div>
+                  
+                  <div>
+                     <head rend="center">III</head>
+                     <lg>
+                        <l>Sphinx lépidoptère au vol variant,</l>
+                        <l>Tour à tour couleur de l‘Ornéode,</l>
+                        <l>Du Panthoüs, des Vulcains, de l‘Atropos,</l>
+                        <l>Du Morpho—Ménélas, de la Danaïde,</l>
+                        <l>De l‘Amaryllis ou de la Saturnie,</l>
+                        <l>Du Polyommate Dispar ou du Papillon Flambé,</l>
+                        <l>Tout à coup il devient quelque immatériel Argus</l>
+                        <l>Qui poudroie et semble nimber d‘idéal</l>
+                        <l>Ses ailes d‘un bleu violet</l>
+                        <l>Flammées de vert,</l>
+                        <l>Ocellées d‘ocre</l>
+                        <l>Et cernées d‘or.</l>
+                        <l>Et voilà qu‘au milieu des Elus, ses précurseurs,</l>
+                        <l>Il tourbillonne ainsi qu‘une immense fleur de punch</l>
+                        <note><ref target="#la_phalange">La Phalange</ref></note>
+                        
+                        <pb
+                           facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f159.item.r=Apollinaire%20manuscrits"
+                           sameAs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f158.item.r=Apollinaire%20manuscrits"/>
+                        
+                        <pb
+                           facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f160.item.r=Apollinaire%20manuscrits"/>
+                        
+                        <l>Dont s‘éclairerait la dernière et verdâtre</l>
+                        <l>Bombance d‘un gargantuesque festin de rêve</l>
+                        <l>Au pays des Burgraves.</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur.</l>
+                     </lg>
+                  </div>
+                  
+                  <div>
+                     <head rend="center">IV</head>
+                     <lg>
+                        <l>Il est le danseur plastique et prestigieux</l>
+                        <l>Qu‘auraient aimé les Porphyrogénètes du Passé.</l>
+                        <l>Parfois, dur aux femmes,</l>
+                        <l>Il offre sa virilité tendue en exagération,</l>
+                        <l>Mais ses rythmes savants</l>
+                        <l>Balancés et cadencés</l>
+                        <l>A la manière des lieds, des rondes et des ballades</l>
+                        <l>Signifient ses intimes intentions</l>
+                        <l>Voilées souvent d‘énigmes.</l>
+                        <l>Parfois aussi ses harmonieux mystères</l>
+                        <l>Rejoignent l'intelligible</l>
+                        <l>Au delà de clartés</l>
+                        <l>Trop éblouissantes</l>
+                        <l>Ou profondes pour certains yeux,</l>
+                        <l>Et l'on subit l‘ineffable évocation</l>
+                        <l>Que susciterait une vaste et vague Musique</l>
+                        <l>Dont l‘ampleur intangible</l>
+                        <l>Porterait les cœurs au pur ravissement.</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur.</l>
+                     </lg>
+                  </div>
+                  
+                  <div>
+                     <head rend="center">V</head>
+                     <lg>
+                        <l>Désinvolte et le plus fabuleux Kaiser</l>
+                        <l>D‘entre les Guillaumes</l>
+                        <l>Casqués et panachés</l>
+                        <l>Qui jamais régnèrent sur de chimériques</l>
+                        <l>Royaumes,</l>
+                        
+                        <pb
+                           facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f161.item.r=Apollinaire%20manuscrits"/>
+                        
+                        <l>Il turbule, en ouragan</l>
+                        <l>Qui ne veut qu‘effleurer, et vole</l>
+                        <l>De la prosternation troublée :</l>
+                        <l>Des océans de blé</l>
+                        <l>A la crête léchante des mers tempêtueuses,</l>
+                        <l>Du sourire embaumé des floraisons coquettes</l>
+                        <l>Aux fronts extasiés des forêts toutes sombres,</l>
+                        <l>Et, par dessus l‘imaginaire acclamation</l>
+                        <l>Des grands'villes</l>
+                        <l>Ramant d‘un pied leste</l>
+                        <l>Avec un large geste</l>
+                        <l>Des bras courbés en arcs de faux,</l>
+                        <l>Le corps dominateur, la tête impériale,</l>
+                        <l>Il passe, tumultuaire comme un délire céleste.</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur.</l>
+                     </lg>
+                  </div>
+                  
+                  <div>
+                     <head rend="center">VI</head>
+                     <lg>
+                        <l>Après, de sylphiques retombées à terre</l>
+                        <l>Il virevolte, espace ses élans,</l>
+                        <l>Compasse ses écarts, s‘époussette</l>
+                        <l>D‘un double et souple</l>
+                        <l>Entrechat, puis il poitrine à nouveau,</l>
+                        <l>S‘éploie en éventail</l>
+                        <l>Et, lyrique, repart vers les nues.</l>
+                        <l>Droit au soleil</l>
+                        <l>Il bondit comme s‘il chevauchait</l>
+                        <l>Un vol d‘aigle,</l>
+                        <l>Et, parmi les griseries des sublimes <ref target="#alcools">« Alcools
+                           »</ref></l>
+                        <l>Et les fumées capiteuses des bravos,</l>
+                        <l>L‘apollonien parterre des poètes émerveillés</l>
+                        <l>Croit voir planer sur son Olympe</l>
+                        <l>L' Hermès annonciateur aux pieds ailés.</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur.</l>
+                     </lg>
+                     <note><ref target="#la_phalange">La Phalange</ref></note>
+                     
+                     <pb
+                        facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f163.item.r=Apollinaire%20manuscrits"
+                        sameAs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f161.item.r=Apollinaire%20manuscrits"
+                     />
+                  </div>
+                  
+                  <div>
+                     <head>VII</head>
+                     <lg>
+                        <l>Sous sa danse polymorphe et versicolore</l>
+                        <l>Qui toupille et pétille au ciel</l>
+                        <l>En mille gerbées de feu d’artifice</l>
+                        <l>Les coupoles des temples et les dômes des mondes</l>
+                        <l>Se prennent de vertige</l>
+                        <l>Et girent,</l>
+                        <l>Comme aux regards d’un enchanteur,</l>
+                        <l>Des œufs d’où vont s’échapper</l>
+                        <l>De neuves et grandioses envergures.</l>
+                        <l><persName ref="#apollinaire_guillaume">Apollinaire</persName> est un fastueux
+                           danseur</l>
+                        <l>Qui tourne, tourne et fait tournoyer</l>
+                        <l>Autour de lui</l>
+                        <l>L’Infini.</l>
+                     </lg>
+                     <p><persName ref="#roinard_paul-napoléon">PAUL NAPOLEON ROINARD</persName></p>
+                  </div>
+               </div>
+            </body>
+         </text>
+         <text>
+            <body>
+               <div type="article" n="162" xml:id="article1_162">
+                  <pb
+                     facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f162.item.r=Apollinaire%20manuscrits"/>
+                  <p>
+                     <lb/>Il vous est certainement arrivé, pour peu que vous n’ayez pas d’auto, de
+                     <lb/>croiser sur le trottoir l’exhilarant ouvrier parisien. Il n’obliquerait pas d’un
+                     <lb/>millimètre de semelle pour ne vous point heurter : au contraire ! « Je suis un
+                     <lb/>citoyen conscient au même titre que vous, veut-il vous faire entendre. Je ne
+                     suis <lb/>donc pas plus bête que vous ». <persName ref="#rimbaud_arthur"
+                        >Rimbaud</persName> me garde de disputer à <persName ref="#apollinaire_guillaume"
+                           >M. Apollinaire</persName>
+                     <lb/>sa part de trottoir en faisant avec lui mon « ouvrier parisien » ! Après
+                     <persName ref="#taine_hippolyte">Taine</persName>, <lb/><persName
+                        ref="#gourmont_remy_de">M. Rémy de Gourmont</persName> a défini l’idée : une image
+                     usée. Il y a des dissociations <lb/>d’images comme il y en a d’idées. S’il y a des
+                     images destinées à devenir lieux <lb/>communs, pas plus que celles de <persName
+                        ref="#rimbaud_arthur">Rimbaud</persName> – qui sont en puissance, - celles de
+                     <lb/><persName ref="#apollinaire_guillaume">M. Apollinaire</persName> n’ont à
+                     redouter ce sort. Ses <ref target="#alcools"><emph rend="italic">Alcools</emph></ref>
+                     ? Il les a bus dans tous les <lb/>pays du monde, et même sur le zinc des bistros de
+                     <placeName ref="#paris">Paris</placeName>. « Je suis ivre d’avoir <lb/>bu tout
+                     l’univers ! » s’écrie t-il. On le serait à moins. Quand j’ai eu fini de lire <lb/>ce
+                     livre, j’étais comme <persName ref="#apollinaire_guillaume">M. Apollinaire</persName>
+                     : ivre. Il y a des morceaux d’un très beau </p>
+                  
+                  <p>
+                     <lb/>lyrisme, tels que <ref target="#vendémiaire" rend="italic">Vendémiaire</ref>,
+                     <ref target="#zone" rend="italic">Zone</ref>, <ref target="#la_maison_des_morts"
+                        rend="italic">La Maison des Morts</ref>, <ref target="#l_Ermite" rend="italic"
+                           >l’Ermite</ref> : <quote rend="italic">
+                              <l>Seigneur, que t’ai-je fait ? Vois. Je suis unicorne ;</l>
+                              <l>Pourtant, malgré son bel effroi concupiscent,</l>
+                              <l>Comme un poupon chéri mon sexe est innocent</l>
+                              <l>D’être anxieux, seul, et debout comme une borne.</l>
+                           </quote>
+                     <lb/>Unicorne de cette façon ! Après tout, pourquoi pas, puisque <persName
+                        ref="#apollinaire_guillaume">M. Apollinaire</persName> nous <lb/>est présenté sous
+                     les traits de tuyaux de cheminées vaguement rapprochés ! (En <lb/>matière de cubisme
+                     de ce calibre je resterai longtemps le dernier – ou, au choix, <lb/>le premier, - des
+                     Béotiens les plus sincères). S’il y a des êtres vivants à la <lb/>surface de la Lune,
+                     c’est sous cet aspect que je me les représente. <note><ref
+                        target="#echo_littéraire_du_boulevard">Echo Littéraire du Boulevard</ref>,
+                        <date when-iso="07-01-1913">1er juillet 1913</date> <persName ref="#bachelin_marie">Marie Bachelin</persName></note>
+                  </p>
+               </div>
+               
+               <div type="article" n="162" xml:id="article2_162">
+                  <p>
+                     <lb/><persName ref="#clouard_henri">M. Henry Clouard</persName>, dans sa petite
+                     anthologie des poètes qu’il nous donne <lb/>à la <ref target="#revue_critique">Revue
+                        critique</ref>, nous entretient assez succinctement de <persName
+                           ref="#apollinaire_guillaume">M. Guillaume <lb/>Apollinaire</persName> ; mais il
+                     est vrai que l’auteur des <ref target="#les_disciplines"><emph rend="italic"
+                        >Disciplines</emph></ref> a soin de nous avertir, <lb/>au seuil de la
+                     chronique, que les livres vont plus vite que nous. </p>
+                  
+                  <p>
+                     <lb/><persName ref="#clouard_henri">M. Clouard</persName> est-il bien sûr que
+                     <persName ref="#apollinaire_guillaume">M. Apollinaire</persName> « se batte les
+                     flancs » ? Nous <lb/>imaginerions tout au plus que <persName
+                        ref="#apollinaire_guillaume">M. G. Apollinaire</persName> se brûlerait ses flancs
+                     d’où <lb/>jaillissent, en flammes pentécotiques, ses poèmes fabuleux, et qu’il ne
+                     pourrait <lb/>se les battre que de ses ailes : sirène gyrante dès qu’il entre en
+                     incubation <lb/>lyrique. </p>
+                  
+                  <p>
+                     <lb/>Ne recrée-t-il pas son univers le poète qui écrivit <ref
+                        target="#les_fiançailles"><emph rend="italic">Fiançailles</emph></ref> dont nous
+                     <lb/>détachons ces quelques vers pour la méditation fructueuse de <persName
+                        ref="#clouard_henri">M. Clouard</persName>, <lb/>dont l’autorité nous semble ici
+                     surprise. <quote rend="italic">
+                        <l>Je n’ai plus même pitié de moi</l>
+                        <l>Et ne puis exprimer mon tourment de silence</l>
+                        <l>Tous les mots que j’avais à dire se sont changés en étoiles.</l>
+                        <l>Un Icare tente de s’élever jusqu’à chacun de mes yeux</l>
+                        <l>Et porteur de soleils je brûle au centre de deux nébuleuses.</l>
+                        <l>Qu’ai-je fait aux bêtes théologales de l’intelligence ?</l>
+                        <l>Jadis les morts sont venus pour m’adorer</l>
+                        <l>Et j’espérais la fin du monde</l>
+                        <l>Mais la mienne arrive en sifflant comme un ouragan</l>
+                     </quote>
+                  </p>
+                  <note><ref target="#la_phalange">La Phalange</ref></note>
+               </div>
+               
+               <div type="article" n="162" xml:id="article3_162">
+                  <p>
+                     <lb/>- Ces <ref target="#alcools"><emph rend="italic">Alcools</emph></ref> de
+                     <persName ref="#apollinaire_guillaume">Guillaume Apollinaire</persName>
+                     <lb/>sont d’ailleurs d’une émouvante et trou- <lb break="no"/>blante beauté.
+                     Donnons-en, pour aujourd’hui, <lb/>un extrait, car c’est bien le « livre dont on
+                     <lb/>parle » : <quote rend="italic">
+                        <ref target="#l_adieu"><title>L'Adieu</title></ref>
+                        <l>J’ai cueilli ce brin de bruyère</l>
+                        <l>L’automne est morte souviens-t-en</l>
+                        <l>Nous ne nous verrons plus sur terre</l>
+                        <l>Odeur du temps brin de bruyère</l>
+                        <l>Et souviens-toi que je t’attends.</l>
+                     </quote>
+                  </p>
+                  <note><ref target="#paris-midi">Paris-Midi</ref></note>
+               </div>
+            </body>
+         </text>
+         <text>
+            <body>
+               <div type="article" n="200" xml:id="article_200" xml:lang="fr">
+                  <pb
+                     facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f200.item.r=Apollinaire%20manuscrits"/>
+                  <cb n="1" rend="left"/>
+                  
+                  <head rend="center">LA LITTERATURE <lb/> ALCOOLS <lb/> PAR <lb/>
+                     <emph rend="bold">GUILLAUME APOLLINAIRE</emph></head>
+                  
+                  <p>
+                     <lb/>Il y a deux jeunesses littéraires. Elles <lb/>marchent parallèlement. Elles ont
+                     des <lb/>formules d‘art, des conceptions intellec— <lb break="no"/>tuelles propres et
+                     se disputent la con— <lb/>quête de la postérité. Toutes deux ont <lb/>leur vérité et
+                     toutes deux, alors même <lb/>qu‘elles s‘en défendraient, sont filles du <lb/>même
+                     effort symboliste qui aux envi— <lb break="np"/>rons de 1880 a opposé l‘idéalisme à
+                     la <lb/>théorie naturaliste. L‘une se fait l‘écho <lb/>du cœur, l‘autre veut au
+                     contraire se <lb/>dégager de ce qu‘elle considère comme <lb/>de la sensiblerie et
+                     laisse dominer la <lb/>raison. Quoi qu‘il en soit, avec des idées <lb/>directrices
+                     différentes et des états d‘âme <lb/>divers, l‘une et l‘autre aboutissent à des
+                     <lb/>œuvres qui ont leur beauté et retien— <lb/>nent l‘attention. Leur différence est
+                     <lb/>moins dans la façon dont elles s‘effor— <lb/>cent d‘échapper aux influences
+                     d‘une lit— <lb break="no"/>térature précédente que dans l‘affirma— <lb break="no"
+                     />tion par l‘une que la poésie doit être <lb/> dans le cœur ou par l‘autre que la
+                     rai— <lb/>son seule est source de poésie. </p>
+                  
+                  <p>
+                     <lb/>La <ref target="#floraison_des_eaux" rend="italic">Floraison des Eaux</ref> et
+                     le <ref target="#du_livre_de_la_mort" rend="italic">Livre de <lb/>la mort</ref> de
+                     <persName ref="#lavaud_guy">Guy Lavaud</persName> furent la plus <lb/>pure et la
+                     plus délicieuse expression <lb/>poétique de la première jeunesse, de cel— <lb/>le qui
+                     comptait les battements de son <lb/>cœur est, en les répétant, se faisait l‘his— <lb
+                        break="no"/>torien d‘une vie intime et profonde. A <lb/>cette tendiance intimiste,
+                     l‘autre jeunes— <lb/>se, moins sentimentale, oppose la sienne <lb/>et l‘œuvre
+                     nouvelle que <persName ref="#apollinaire_guillaume">Guillaume Apol—
+                        <lb/>linaire</persName> publie aux éditions du Mercure <lb/>de France a le mérite
+                     d‘exprimer d‘une <lb/>façon complète sa manière propre que <lb/>l‘on pourrait appeler
+                     la sensibilité de Ia <lb/>raison. </p>
+                  
+                  <p>
+                     <lb/>En éditant sous le titre d'<ref target="#alcools" rend="italic">Alcools</ref>
+                     di— <lb break="no"/>vers poèmes écrits au cours d‘une pé— <lb break="no"/>riode qui
+                     va de 1898 à 1913, <persName ref="#apollinaire_guillaume">Guillaume
+                        <lb/>Apollinaire</persName> a réuni les éléments indica— <lb/>tifs d‘une poésie
+                     hardie, purement in— <lb/>tellectuelle, où les souvenirs personnels <lb/>ne
+                     communiquent au cœur qu‘une part <lb/>légère d‘émotion. Encore que tous ces
+                     <lb/>souvenirs soient les vies successivement <lb/>vécues par le poète qui donne au
+                     récit <lb/>qu‘il en esquisse la valeur d‘un symbole <lb/>mirifique et parfaitement
+                     original. </p>
+                  
+                  <p>
+                     <lb/>En vérité ce livre est un des plus cu— <lb/>rieux qui aient paru au cours de ces
+                     <cb n="2" rend="right"/>
+                     <lb/>dernières années et bien peu des écri— <lb break="no"/>vains qui se trouvent du
+                     même bord <lb/>que l‘auteur d‘<ref target="#alcools" rend="italic">Alcools</ref>
+                     connaissent com— <lb break="no"/>me lui l‘art de parter une langue plus <lb/>neuve et
+                     savent mieux que lui faire <lb/>rendre aux mots sybillins tout leur sens <lb/><emph
+                        rend="italic">originel</emph> et toute leur force profonde. Sa <lb/>phrase fonmée
+                     des mots essentiels se <lb/>prolonge dans la saveur qui en demeu— <lb break="no"/>re.
+                     Ce style concis, buriné, à la fois mys— <lb break="no"/>tique et concret est d‘une
+                     vigueur ri— <lb break="no"/>goureusement classique qui fait parfois <lb/>penser à la
+                     langue subtile d‘un <persName ref="#villon_françois">Villon</persName>
+                     <lb/>ou d‘un <persName ref="#marot_clément">Clément Marot</persName>. </p>
+                  
+                  <p>
+                     <lb/><persName ref="#apollinaire_guillaume">Guillaume Apollinaire</persName> établit
+                     que l‘ar— <lb break="no"/>tiste doit être SOI : il ne l‘est qu‘en re— <lb break="no"
+                     />jetant les émotions accessibles de l‘âme <lb/>vulgaire et en parlant un langage
+                     éloi— <lb break="np"/>gné des rhétoriques banales. Ainsi très <lb/>courageusement, au
+                     risque peut—être de <lb/>frayer avec l‘excès, donnera—t—il sa sym— <lb break="no"
+                     />pathie aux manifestations intellectuelles <lb/>dont les hardiesses de ces derniers
+                     <lb/>temps ont apeuré les bourgeois gentils— <lb/>hommes, les conservateurs anodins
+                     de <lb/>la littérature et des arts. Ainsi évitera— <lb/>t—il de se faire l‘éditeur
+                     d‘idées généra— <lb/>les dont, pour le moins qu‘on puisse di— <lb break="no"/>re,
+                     c‘est que, étant générales, elles ces— <lb break="no"/>sent d‘être intéressantes
+                     quand elles ne <lb/>parviennet pas à être tout à fait niaises. <lb/>Ainsi pour rendre
+                     et définir ses impres— <lb break="no"/>sions a—t—il soin de le faire en formules
+                     <lb/>qui font jaillir du cœur et surtout de <lb/>l‘esprit le rayon d‘une lumiière
+                     variée à <lb/>l'infini : <lb/>dit—il dans le <ref target="#le_voyageur">poème du
+                        voyageur</ref> : <quote rend="small">
+                           <l>Te souviens—tu du long orphelinat des gares</l>
+                           <l>Nous traversâmes des villes qui tout le jour <lb rend="interline"
+                           />(tournaient:dans l'interligne, pour terminer le vers malgré le manque de
+                              place)</l>
+                           <l>Et vomissaient la nuit le soleil des journées.</l>
+                        </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Quelle vibration vaudra celle du poète <lb/>évoquant le défilé des souvenirs qui
+                     <lb/>constituent sa vie : <lb/>et quel symbolisme plus inquiet que ce— <lb/>lui que
+                     l‘on retrouve dans l‘affabulation <lb/>de Merlin et la vieille femme : <quote
+                        rend="small italic">
+                        <l>Les villes que j‘ai vues vivaient comme des <lb rend="interline"/>folles</l>
+                        <l>Au carrefour où nulle fleur sinon la rose</l>
+                        <l>Des vents mais sans épines n‘a fleuri l'univers</l>
+                        <l>Merlin guettait la vie et l‘éternelle cause</l>
+                        <l>Qui fait mourir et puis renaître l'univers.</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Il n‘y a point trace chez <persName ref="#apollinaire_guillaume">Guil. Apol— <lb
+                        break="no"/>linaire</persName> d‘une vaine et futile émotion. Il <lb/>passe à
+                     côté des choses de la vie en ar— <lb break="no"/>tiste hautain et s‘il ne dédaigne
+                     pas, Ma— <lb break="no"/>ge du verbe, de la mélodie et de la cou— <lb break="no"
+                     />leur, de s‘arrêter aux sensations que la <lb/>formidable Nature impose aux poètes,
+                     <lb/>du moins il a l‘orgueil de ne les traduire <lb/>que sous une forme personnelle,
+                     dans <lb/>un vocabulaire qui porte le témoignage <lb/>d‘une érudition nourrie aux
+                     festins, <lb/>somptueux de la divine et féconde fan— <lb break="no"/>taisie antique.
+                     Le poète <persName ref="#royère_jean">Jean Royère</persName>
+                     <lb/>écrit dans <ref target="#la_phalange">la Phalange</ref> : <quote>« <ref
+                        target="#larron">Le Larron</ref>
+                        <lb/>(un des poèmes d‘<ref target="#alcools" rend="italic">Alcools</ref>) est
+                        herméti— <lb break="no"/> que d‘être un amas de symboles, de <lb/>lueurs, encore
+                        qu‘il y ait dans la pen— <lb break="no"/>sée d‘<persName
+                           ref="#apollinaire_guillaume">Apollinaire</persName> une ingénuité qui ré— <lb
+                              break="no"/>pugne aux simples intuitions. Sa pen— <lb break="no"/>sée le
+                        possède toujours : mais il s‘évade <lb/>des lacs syllogistiques par son imagina—
+                        <lb break="no"/>tion, hardie et sûre d‘elle et par le goût. <lb/>C‘est un poète
+                        d‘un tact très décisif. <lb/>Cette obscurité est un bénéfice pour le <lb/>lecteur
+                        qu‘elle stimule et induit en poé— <lb break="no"/>sie. »</quote>
+                  </p>
+                  <note><ref target="#la_démocratie_sociale">La Démocratie Sociale</ref>
+                     <date when-iso="08-09-1913">18 août 1913</date></note>
+               </div>
+            </body>
+         </text>
+         <text>
+            <body>
+               <div type="article" n="202" xml:id="article_202">
+                  <pb
+                     facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f202.item.r=Apollinaire%20manuscrits"/>
+                  <cb n="1" rend="left"/>
+                  <head>CARNET D'UN BRAILLARD <lb/>
+                     <ref target="#alcools">« ALCOOLS »</ref></head>
+                  
+                  <p>
+                     <lb/>Nous connaissions déjà beaucoup de ces <lb/>poèmes donnés au hasard des revues.
+                     Ce <lb/>fut donc pour nous grande joie que d‘ouvrir <lb/>large le livre que le <ref
+                        target="#le_mercure_de_france"><emph rend="italic">Mercure de France</emph></ref>
+                     ve— <lb break="no"/>nait de publier afin d'y retoruver moult <lb/>jolies choses. </p>
+                  
+                  <p>
+                     <lb/>Nous confessons sans grand‘honte qu‘il <lb/>nous est malaisé de parler de
+                     <persName ref="#apollinaire_guillaume">G. Apolli— <lb break="no"
+                     />naire</persName>, car en vérité c‘est un peu toute cette <lb/>école : les
+                     Fantaisistes qu‘il nous faudrait <lb/>effleurer. </p>
+                  
+                  <p>
+                     <lb/>Or, se trouve en ladite écôle une demi— <lb break="no"/>douzaine au moins de
+                     fameux poètes, à <lb/>commencer par <persName ref="#merrill_stuart"
+                        >Stuart—Merrill</persName> et puis à sui— <lb break="no"/>vre : <persName
+                           ref="#salmon_andré">A. Salmon</persName>, <persName ref="#dereme_tristan">T.
+                              Derème</persName>, <persName ref="#carco_francis">F. Carco</persName> et
+                     <lb/>celui sur qui je dis : <persName ref="#apollinaire_guillaume">Guillaume Apolli—
+                        <lb break="no"/>naire</persName>. </p>
+                  
+                  <p>
+                     <lb/>Et puis, ce dernier est aussi insaisissable <lb/>qu‘anguille en vase ! Donc vous
+                     saurez que <lb/>s‘il confesse : <quote>
+                        <l>Seul en Europe tu n‘es pas antique ô Christia—<lb rend="interline"/>nisme</l>
+                        <l> Et toi que les fenêtres observent la honte te <lb rend="interline"
+                        />retient</l>
+                        <l> D‘entrer dans une église et de t‘y confesser ce <lb rend="interline"
+                        />matin</l>
+                     </quote>
+                     <lb/>Il ne faudra pas vous hâter de proclamer : <lb/><persName
+                        ref="#apollinaire_guillaume">G. Apollinaire</persName> est obsédé d‘un idéal chré—
+                     <lb break="no"/>tien. Car alors il <emph rend="italic">craquera</emph> une
+                     allumette, <lb/>allumera sa pipe sous votre nez et puis, <lb/>souriant, vous conduira
+                     vers la danse de <lb/>Salomé : <quote>« Prends, dit—elle au fou du roi, <lb/>« Prends
+                        cette tête au lieu de ta marotte et danse <lb/>Sire marchez devant trabants
+                        marchez derrière <lb/>Nous creuserons un trou et l‘y enterrerons <lb/>Nous
+                        planterons des fleurs et danserons en rond <lb/>Jusqu‘à l‘heure où j‘aurai perdu
+                        ma jarretière</quote>
+                  </p>
+                  
+                  <p>
+                     <lb/><persName ref="#apollinaire_guillaume">Guillaume Apollinaire</persName> est
+                     inquiet, di- <lb break="no"/>rait—on, des réalités. Il se penche, regarde,
+                     <lb/>sourit, se penche encore et pleure. Mais <lb/><persName
+                        ref="#apollinaire_guillaume">Apollinaire</persName> ne veut point pleurer trop
+                     long— <lb break="no"/>temps. : une larme ? un beau vers. </p>
+                  
+                  <p>
+                     <lb/>Et c‘est ainsi que délaissant « cette litté— <lb break="no"/>rature de cocu » ——
+                     ainsi <persName ref="#salmon_andré">A. Salmon</persName> quali— <lb/>fie—il quelque
+                     part la poésie de <persName ref="#musset_alfred_de">Musset</persName> — <lb
+                        break="no"/>c‘est ainsi donc qu‘<persName ref="#apollinaire_guillaume"
+                           >Apollinaire</persName> ne nous par— <lb/>lera guère de son pauvre petit cœur qui
+                     <lb/>saigne, ou de sa chère âme meurtrie qui <lb/>sanglote. Il écrira en toute
+                     simplicité, en <lb/>grand'beauté : : <quote rend="center">
+                        <l>Dans la cour je pleure à Paris</l>
+                        <l>Moi qui sais des lais pour les reines</l>
+                        <l>Les complaintes de mes années</l>
+                        <l>Des hymnes d‘esclave aux murènes</l>
+                        <l>La romance du mal—aimé</l>
+                        <l>Et des chansons pour les sirènes</l>
+                     </quote>
+                     <lb/>et puis il ne s‘attardera pas. Demain, un <lb/>soleil jeune fera s‘ouvrir des
+                     feuilles d‘or, <lb/>l‘air sera cher aux poumons ; Apollinaire <lb/>accordera donc son
+                     cœur à un thème gra— <lb break="no"/>cieux et charmant que lui souffle la brise :
+                     <quote rend="center">
+                        <l>C‘est le printemps viens—t—en Pâquette</l>
+                        <l>Te promener au bois joli</l>
+                        <l>Les poules dans la cour caquètent</l>
+                        <l>L‘aube au ciel fait des roses plis</l>
+                        <l>L‘amour chemine à ta conquête</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Plus loin nous ferons connaissance avec <lb/>de pâles voyous, avec des brigands
+                     loqua— <lb break="no"/>ces et alcooliques qui ripaillent en gaieté <lb/>avant d'aller
+                     assassiner. <persName ref="#apollinaire_guillaume">Apollinaire</persName> a ses
+                     <lb/>entrées partout : il vous conduira encore à <lb/>un bal où les invités sont des
+                     squelettes. <lb/>À un détour du chemin, il vous présentera <lb/>sans doute à son
+                     vieil ami le Juif errant. <lb/>Amusé de votre stupeur, il vous conviera <lb/>enfin à
+                     l'étrange spectacle où : <cb n="2" rend="right"/>
+                     <quote rend="center">
+                        <l>Sur les tréteaux l‘arlequin blème</l>
+                        <l>Salue d‘abord les spectateurs</l>
+                        <l>Des sorciers venus de Bohème</l>
+                        <l>Quelques fées et les enchanteurs</l>
+                        <l>Ayant décroché une étoile</l>
+                        <l>Il la manie à bras tendu</l>
+                        <l>Tandis que des pieds un pendu</l>
+                        <l>Sonne en mesure les cymbales</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Vous croyez, enfin, avoir saisi <persName ref="#apollinaire_guillaume">Apolli—
+                        <lb break="no"/>naire</persName> et vous parlez de scepticisme joyeux,
+                     <lb/>prèts à réclamer de lui encore un secret. <lb/> Mais lui, ces spectacies, ces
+                     vices, cette <lb/>pouillerie, les Zaporogues, les Tziganes, <lb/>tous ces êtres
+                     étranges, difformes, brutaux, <lb/>guenillards, somptueux, tout ce monde dont <lb/>il
+                     fait de la beauté ne l'intéresse plus. <lb/>Tout à l‘heure il va vous conter une
+                     légen— <lb break="no"/>de douce et jolie où il mettra toute sa sen— <lb break="no"
+                     />sibilité ingénue Il n‘a plus pour vous de <lb/> secret, mais il tourne la tête et
+                     l‘Amour <lb/>qui le fit souffrir « à vingt et à trente ans » <lb/>lui ravive un
+                     ancien tourment, ainsi vous <lb/> l‘entendez, il murmure : <quote rend="center">
+                        <l>J‘ai cueilli ce brin de bruyère</l>
+                        <l>L‘automne est morte souviens—t‘en</l>
+                        <l>Nous ne nous verrons plus sur terre</l>
+                        <l>Odeur du temps orin de bruyère</l>
+                        <l>Et souviens—toi que je t‘attends</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>En résumé, <ref target="#alcools"><emph rend="italic">Alcools</emph></ref> est
+                     le meilleur livre <lb/>de vers paru cette année. C‘est tout ce qu‘il <lb/>importe de
+                     dire et nous n‘avons pas voulu <lb/>faire plus. </p>
+                  
+                  <p>
+                     <lb/>L‘Art des fantaisistes n‘est point de ceux <lb/>que l‘on peut disséquer à
+                     plaisir, dont on <lb/>puisse discuter avec profit la technique ou <lb/>les
+                     productions. Nous l‘avons dit, tous les <lb/>poètes qui le pratiquent ont du talent
+                     et <lb/>prétendre exercer un droit de critique se— <lb break="no"/>rait mener œuvre
+                     de boucher. On com— <lb/>prend que ça n‘était guère notre but et si <lb/><persName
+                        ref="#apollinaire_guillaume">Apollinaire</persName> est parfois déconcertant, du
+                     <lb/>moins, en nous promenant de <placeName ref="#paris">Paris</placeName> à
+                     <placeName ref="#prague">Pra- <lb/>gue</placeName> ou à <placeName
+                        ref="#amsterdam">Amsterdam</placeName>, ou de <placeName ref="#londres"
+                           >Londres</placeName> en <lb/><placeName ref="#ukraine">Ukraine</placeName>, nous
+                     a-t-il montré que partout, <lb/>joie ou douleur, rêve ou réalité, dans leur
+                     <lb/>intensité même, avaient leurs équivalents <lb/>en beaux vers. </p>
+                  
+                  <p>
+                     <lb/>Ces équivalences, il les a cherchées et, <lb/>les ayant trouvées, il nous a
+                     enchantés. <lb/>Nous ne saurions avoir plus de raison de <lb/>l'aimer si ce n'est
+                     notre conviction qu'<persName ref="#apollinaire_guillaume">Apol- <lb break="no"
+                     />linaire</persName>, avec les poètes précités - et sur <lb/>lesquels ous
+                     reviendrons à notre plaisir - <lb break="np"/>nous fait pressentir une renaissance de
+                     la <lb/>bonne tradition car ils sont humains et <lb/>français. </p>
+                  
+                  <p>
+                     <lb/>Et ainsi nous comptons sur cette école <lb/>des fantaisistes pour marquer la fin
+                     de no- <lb/>tre siècle de transition où manque la foi <lb/>où manque l'enthousiasme. </p>
+                  <p><ref>Jack Mercereau</ref></p>
+                  <note><ref target="#paris-journal">Paris-Journal</ref>
+                     <date when-iso="11-02-1913">2 Novembre 1913</date></note>
+               </div>
+            </body>
+         </text>
+         <text>
+            <body>
+               <div type="article" n="206" xml:id="article_206">
+                  <pb
+                     facs="https://gallica.bnf.fr/ark:/12148/btv1b525088021/f206.item.r=Apollinaire%20manuscrits"/>
+                  <cb n="1" rend="left"/>
+                  
+                  <p>
+                     <lb/>Ce n'est pas au Lycée de <placeName ref="#nice">Nice</placeName> que j'ai
+                     <lb/>connu <persName ref="#apollinaire_guillaume">Guillaume Apollinaire</persName> ;
+                     nous y <lb/>fûmes cependant élevés en partie et il <lb/>nous arrive de découvrir que
+                     nous <lb/>eûmes à quelque intervalle les mêmes <lb/>maîtres. Un souvenir en appelle
+                     d'au- <lb break="np"/>tres, et, dans le petit restaurant du <placeName
+                        ref="#boulevard_saint_germain">bou- <lb break="no"/>levard
+                        Saint-Germain</placeName>, où je déjeune <lb/>souvent avec le poète d'<ref
+                           target="#alcools"><emph rend="italic">Alcools</emph></ref>, le repas <lb/>s'achève
+                     bien des fois que nous parlons <lb/>encore du temps où nous hantions la
+                     <lb/>permanence et le jardin qu'on nous in- <lb break="no"/>terdisait en vain. </p>
+                  
+                  <p>
+                     <lb/>Je l'avoue : si <persName ref="#apollinaire_guillaume">Guillaume
+                        Apollinaire</persName>
+                     <lb/>ne fut pas un élève brillant, je n'ai rien <lb/>à lui envier... Douce permanence
+                     ! <lb/>Que d'heures charmantes elle nous a <lb/>valu. Nous y trouvions le calme
+                     absolu <lb/>de l'exil, et tandis que nos camarades <lb/>déclinaient : rosa, la rose,
+                     ou tradui- <lb/>saient les <ref target="#fables_d_ésope">fables d'Esope</ref>, un
+                     rayon de <lb/>soleil glissant sur un pupitre suffisait <lb/>à notre bonheur. Le
+                     répétiteur, dans sa <lb/>chaire, somnolait. Du <placeName ref="#quai_félix_faure"
+                        >quai Félix-Faure</placeName>
+                     <lb/>arrivait la rumeur des voitures et le <lb/>rayon de soleil tournait ; il
+                     éblouissait <lb/>les murs blanchis à la chaux... Nous <lb/>attendions... Enfin, le
+                     tambour du con- <lb break="no"/>cierge roulait sous le préau et nous nous
+                     <lb/>hâtions vers la sortie. </p>
+                  
+                  <p>
+                     <lb/>Le jardin, lui aussi, nous procurait <lb/>des joies profondes. A sa place,
+                     aujour- <lb break="no"/>d'hui s'élève le bâtiment neuf qui bor- <lb/>de la <placeName
+                        ref="#rue_gioffredo">rue Gioffredo</placeName>. Mais alors les hauts
+                     <lb/>eucalyptus, les platanes, les sureaux et <lb/>les orangers, en faisaient une
+                     retraite <lb/>délicieuse où l'oeil du surveillant géné- <lb break="no"/>ral ne savait
+                     pas nous découvrir. A <lb/>trois ou quatre, nous escaladions les ar- <lb break="no"
+                     />bres et, protégés par le feuillage, nous <lb/>restions à califourchon sur une bran-
+                     <lb break="no"/>che pendant toute la durée de la clas- <lb break="no"/>se...
+                     Evidemment, la discipline n'y per- <lb/>dait rien, mais nous préférions les
+                     <lb/>longs pensums et les retenues du di- <lb break="no"/>manche, qu'on n'omettait
+                     pas de nous <lb/>infiger, à l'enseignement du grec, du <lb/>latin et même du
+                     français. </p>
+                  
+                  <p>
+                     <lb/>N'avons-nous pas gardé dans la vie, <lb/>d'ailleurs, cet amour des choses défen-
+                     <lb break="no"/>dues et l'instinct puissant de l'indépen- <lb break="no"/>dance ?
+                     <persName ref="#apollinaire_guillaume">Apollinaire</persName>, qui commit cent
+                     <lb/>folies, est encore prêt, je crois, à les <lb/>commettre. La place que lui a
+                     donné <lb/>son talent dans la littérature actuelle, <lb/>il ne la doit à aucune
+                     contrainte. Ses li- <lb break="no"/>vres le démontreraient.. Ils sont pleins <lb/>de
+                     ce naturel aimable qui lui fit écrire <lb/>tant de pages ingénues et savoureuses
+                     <lb/>et tant de petits poèmes aussi purs que <lb/>celui-là: <quote rend="center">
+                        <l>Je demande dans ma maison</l>
+                        <l>Une femme ayant sa raison,</l>
+                        <l>Un Chat passant parmi des livres,</l>
+                        <l>Des amis en toute saison,</l>
+                        <l>Sans lesquels je ne puis pas vivre.</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Il n'habitait <placeName ref="#nice">Nice</placeName> que l'hiver. Pen-
+                     <lb/>dant les autres mois de l'année, il vaga- <lb/>bonfait selon l'humeur des siens,
+                     tan- <lb/>tôt à l'étranger, tantôt en <placeName ref="#france">France</placeName>,
+                     ici et <lb/>là... Quelle vie ! J'ai connu ces départs <cb n="2" rend="center"/>
+                     <lb/>où tout à la fois vous manque, ces arri- <lb break="no"/>vées dans l'inconnu,
+                     l'hôtel, les paque- <lb/>bots et les trains. Mais, toujours, mon <lb/>esprit revenait
+                     à <placeName ref="#nice">Nice</placeName>. A travers les gri- <lb break="no"
+                     />sailles, ou sous le vent du large, ou <lb/>par les petites pluies méticuleuses de
+                     <lb/>province, je ne pouvais imaginer, sans <lb/>un serrement de coeur, le soleil et
+                     le ciel <lb/>si beaux qui, là-bas, sur une ville blan- <lb break="no"/>che, au bord
+                     de la mer, se lèvent cha- <lb/>que jour pour le bonheur de tous. </p>
+                  
+                  <p>
+                     <lb/>Une mélancolie poignate s'empare <lb/>à la longue de ces rêves les plus tendres.
+                     <lb/>Cet enfant, cet adolescent, cet homme <lb/>est formé pour longtemps. Il n'aura
+                     <lb/>pas, comme la plupart de ses amis, cette <lb/> sécurité, cette précieuse et
+                     grave séré- <lb break="no"/>nité de ceux qui, toujours, vécurent au <lb/>même
+                     endroit. </p>
+                  
+                  <p>
+                     <lb/>Rappelez-vous les vers d'<persName ref="#bataille_henry">Henry Ba-
+                        <lb/>taille</persName> : <quote>
+                           <l>As-tu pleuré ? Oui, j'ai pleuré. As-tu souffert ?</l>
+                           <l>Oui, j'ai souffert. Et qu'en as-tu gardé ? Rien.</l>
+                           <l>Des dates comme des vieilles lettres... Oui, j'ai souf-<lb rend="interline"
+                           />fert !</l>
+                           <l>Un mouvement incessant vers des demeures nou-<lb rend="interline"/>velles</l>
+                           <l>M'a porté jusqu'à vous. Et les regrets ? Non. Quels ?</l>
+                           <l>Pourtant les lieux que l'on aimait... J'ai tant voyagé.</l>
+                           <l>Ne vous ai-je pas dit que, souvent, je me lève</l>
+                           <l>Pour chercher un objet que je crois avoir posé</l>
+                           <l>Dans telle chambre, à tel endroit. « Mais, non. Je <lb rend="interline"
+                           />rêve.</l>
+                           <l>C'était à Bordeaux, dis-je... non, c'était à Lyon...</l>
+                           <l>Ou la dernière fois que je fus à Marseille... »</l>
+                           <l>J'ai quelquefois pleuré de tout ce qui s'éveille</l>
+                           <l>Et renaît d'une si mystérieuse confusion. </l>
+                        </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>En connaissons-nous de ces perpé- <lb break="no"/>tuels errants ! Ils passent...
+                     Où vont- <lb/>ils ?... Plus tard !... Plus tard!... ou <lb/>bien nous le saurons
+                     jamais. </p>
+                  
+                  <p>
+                     <lb/>Comme <persName ref="#bataille_henry">Henry Bataille</persName>, <persName
+                        ref="#apollinaire_guillaume">Guillaume <lb/>Apollinaire</persName> a noté
+                     jusqu'aux nuances <lb/>les plus subtiles du découragement qui <lb/>s'empare d'une
+                     homme à qui tout s'of- <lb break="no"/>fre, à chaque instant, dans le spectacle
+                     <lb/>de sa dispersion. Il voudrait, hélas ! <lb/>que la minute qui passe fût
+                     éternelle. <lb/>Il s'attache aux formes les plus périssa- <lb break="no"/>bles du
+                     moment et les supplie de ne <lb/>pas le décevoir. <quote rend="center">
+                        <l>J'ai cueilli ce brin de bruyère.</l>
+                        <l>L'automne est morte, souviens-t'en.</l>
+                        <l>Nous ne nous verrons plus sur terre,</l>
+                        <l>Odeur du temps, brin de bruyère...</l>
+                        <l>Et souviens-toi que je t'attends !</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Souviens-toi ! Mais il n'est pas dupe. <lb/>Il sait que tout nous échappe et
+                     nous <lb/>blesse et quand il se plaint il imprime <lb/>à son pathétique un mouvement
+                     d'une <lb/>discrétion parfaite. <quote rend="center">
+                        <l>Je passais au bord de la Seine,</l>
+                        <l>Un livre ancien sous le bras.</l>
+                        <l>Le fleuve est pareil à ma peine...</l>
+                        <l>Il s'écoute et ne tarit pas...</l>
+                        <l>Quand donc finira la semaine !</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Son oeuvre entière aboutit à cette dé- <lb break="no"/>chirante inquiétude et je
+                     ne connais <lb/>pas de miroir plus fidèle d'une âme de <lb/>poète. Elle nous permet
+                     en effet de <lb/>saisir toutes les attitudes qu'il veut <lb/>prendre et quelquefois
+                     la parodie qu'il <lb/>fait de sa trop grande détresse quand <lb/>il lui sied d'être
+                     un matin de bonne <lb/>humeur. </p>
+                  
+                  <p>
+                     <lb/><persName ref="#apollinaire_guillaume">Apollinaire</persName> n'est pas un
+                     anguissant <lb/>et fade artiste. Au contraire ! Il est <lb/>gaillard ; il est mordant
+                     et je ne veux, <lb/>pour preuve de son attachement aux <lb/>joies quotidiennes, que
+                     les étonnants <cb n="3" rend="right"/>
+                     <lb/>menus qu'il élabore sous l'oeil effaré <lb/>de notre bon garçon de restaurant. <quote>
+                        <p>
+                           <lb/>« Le premier devoir d'un homme, <lb/>« assure un cabaret de Montmartre où
+                           <lb/>« nous fréquentions autrefois, est d'a- <lb/>« bon estomac ».</p>
+                     </quote>
+                     <lb/>N'est-il pas vrai ? </p>
+                  
+                  <p>
+                     <lb/>Cependant, pour ne pas négliger les <lb/>contrastes, j'ajoute maintenant que je
+                     <lb/>connus, au lycée de <placeName ref="#nice">Nice</placeName>, un poète si
+                     <lb/>opposé de goût, de style et d'existence <lb/>au précédent, qu'il faut bien que
+                     j'en <lb/>parle ici. <persName ref="#cappatti_louis">Louis Cappati</persName> est
+                     plus jeune <lb/>qu'<persName ref="#apollinaire_guillaume">Apollinaire</persName>. Il
+                     a mon âge et sa na- <lb break="no"/>ture sans artifice me plaît. Elle dénote <lb/>un
+                     caractère. En plus, la force que je <lb/>découvre dans ses vers n'est pas négli- <lb
+                        break="no"/>geable. Ce jeune homme chérit son <lb/>pays. Il aime <placeName
+                           ref="#nice">Nice</placeName>. Il y vit actuellement <lb/>et les deux livres qu'il
+                     a déjà publiés <lb/>l'acheminent, sans détour, vers une ex- <lb break="no"/>pression
+                     vigoureuse de la beauté de nos <lb/>montagnes, de nos rivages et de la lu- <lb
+                        break="no"/>mière étincelante qui frappe notre ciel. </p>
+                  
+                  <p>
+                     <lb/>Son inspiration n'a rien d'étroitement <lb/>local. Elle trouve, dans la coupe
+                     ramas- <lb break="no"/>sée de ses meilleurs poèmes la forme <lb/>véhémente qui lui
+                     convient. </p>
+                  
+                  <p>
+                     <lb/>Il s'écrie : <quote>
+                        <l>... Je t'évoque, ô sombre Mëcris,</l>
+                        <l>Entre tes sapins noirs, je vois les Alpes blanches,</l>
+                        <l>Près des monts désolés,sous la nuit de tes branches,</l>
+                        <l>J'erre en ton bois profond qui n'a ni chant, ni cris.</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Cette violence a de l'allure. Je ne sais <lb/>pas ce que Louis Cappatti
+                     réalisera de- <lb break="no"/>main, mais il faut attendre beaucoup <lb/>de sa précoce
+                     expérience. </p>
+                  
+                  <p>
+                     <lb/>Mes lecteurs, certainement, le con- <lb break="no"/>naissent autant que moi et,
+                     déjà, ont-ils <lb/>fait crédit au poète qui écrivit avec cette <lb/>belle assurance
+                     de rythme : <quote>
+                        <l>S'il brille dans mes vers quelques éclairs de beauté,</l>
+                        <l>Si jamais je dois être orgueilleux de la flamme</l>
+                        <l>Qu'un Dieu mystérieux entretient dans mon âme,</l>
+                        <l>Pallas, fais-moi chanter la force et la raison.</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Et le poème s'achève sur cette large <lb/>et saine supplication : <quote>
+                        <l>Fais entrer le soleil d'Hellas dans ma maison.</l>
+                     </quote>
+                  </p>
+                  
+                  <p>
+                     <lb/>Il est encore d'autres poètes dans no- <lb break="no"/>tre admirable pays et
+                     personne ne l'i- <lb break="no"/>gnore ; mais, en parlant de <persName
+                        ref="#apollinaire_guillaume">Guillaume <lb/>Apollinaire</persName> et de <persName
+                           ref="#cappatti_louis">Louis Cappatti</persName>, j'ai <lb/>voulu montrer avec
+                     quelle heureuse di- <lb break="no"/>versité notre ciel savait toucher les <lb/>coeurs
+                     sensibles. N'allons pas plus loin. <lb/>Il suffit que la Poésie reçoive un si bril-
+                     <lb break="no"/>lant hommage. </p>
+                  <p rend="align right"><persName ref="#carco_francis">Francis Carco</persName>.</p>
+                  <note rend="handwritten"><ref target="#le_petit_niçois">Le Petit Niçois</ref>
+                     <date when-iso="07-31-1913">31 Juillet 1913</date></note>
+               </div>
+            </body>
+         </text>
+      </group>
+   </text>
+   <standOff>
+      <listPerson>
+         <person xml:id="apollinaire_guillaume">
+            <persName><forename>Guillaume</forename><surname>Apollinaire</surname></persName>
+         </person>
+         <person xml:id="guy_lavaud">
+            <persName><forename>Guy</forename><surname>Lavaud</surname></persName>
+            <note>Poète symboliste français, né en 1883 à Terrasson, France, et mort en 1958 à
+               Saint-Germain-en-Laye, France.</note>
+         </person>
+         <person xml:id="françois_villon">
+            <persName><forename>François</forename><surname>Villon</surname></persName>
+            <note>Célèbre poète français de la fin du Moyen Âge, né en 1431 à Paris, France, et mort
+               après 1463.</note>
+         </person>
+         <person xml:id="clement_marot">
+            <persName><forename>Clément</forename><surname>Marot</surname></persName>
+            <note>Poète français de la Renaissance, né en 1496 à Cahors, France, et mort en 1544, à
+               Turin, Italie.</note>
+         </person>
+         <person xml:id="jean_royere">
+            <persName><forename>Jean</forename><surname>Royère</surname></persName>
+            <note>Poète et éditeur français, né en 1871 à Aix-en-Provence, France, et mort en 1956 à
+               Paris, France.</note>
+         </person>
+         <person xml:id="roinard_paul-napoléon">
+            <persName><forename>Paul-Napoléon</forename><surname>Roinard</surname></persName>
+            <note>Poète anarchiste français, né en 1856 à Neufchâtel-en-Bray, France,, et mort à
+               Courbevoie, France, en 1930.</note>
+         </person>
+         <person xml:id="rimbaud_arthur">
+            <persName><forename>Arthur</forename><surname>Rimbaud</surname></persName>
+            <note>Poète français né en 1854 à Charleville-Mézières, France, et mort en 1891 à
+               Marseille, France.</note>
+         </person>
+         <person xml:id="taine_hippolyte">
+            <persName><forename>Hippolyte</forename><surname>Taine</surname></persName>
+            <note>Philosophe et historien français, né en 1828 à Vouziers, France, et mort en 1893 à
+               Paris, France.</note>
+         </person>
+         <person xml:id="gourmont_remy_de">
+            <persName><forename>Remy</forename><nameLink>de</nameLink><surname>Gourmont</surname></persName>
+            <note>Ecrivain, romancier, journaliste et critique d'art français, né en 1858 à
+               Bazoches-au-Houlme, France, et mort en 1915 à Paris, France.</note>
+         </person>
+         <person xml:id="bachelin_marie">
+            <persName><forename>Marie</forename><surname>Bachelin</surname></persName>
+            <note>Journaliste pour l'Echo Littéraire du Boulevard</note>
+         </person>
+         <person xml:id="clouard_henri">
+            <persName><forename>Henri</forename><surname>Clouard</surname></persName>
+            <note>Journaliste et critique littéraire français né en 1889 et mort en 1974.</note>
+         </person>
+         <person xml:id="merrill_stuart">
+            <persName><forename>Stuart</forename><surname>Merrill</surname></persName>
+            <note>Poète américain, né en 1863 à Hempstead, New York, Etats-Unis d'Amérique, et mort
+               en 1915 à Versailles, France.</note>
+         </person>
+         <person xml:id="salmon_andré">
+            <persName><forename>André</forename><surname>Salmon</surname></persName>
+            <note>Ecrivain, poète, romancier, journaliste et critique d'art français né en 1881 à
+               Paris, France, et mort en 1969 à Sanary-sur-Mer, France.</note>
+         </person>
+         <person xml:id="dereme_tristan">
+            <persName><forename>Tristan</forename><surname>Derème</surname></persName>
+            <note>Poète et écrivain français né en 1889 et mort en 1941 à Oloron-Sainte-Marie,
+               France.</note>
+         </person>
+         <person xml:id="carco_francis">
+            <persName><forename>Francis</forename><surname>Carco</surname></persName>
+            <note>Ecrivain, poète, journaliste et parolier français né en 1886 à Nouméa,
+               Nouvelle-Calédonie, et mort en 1958 à Paris, France.</note>
+         </person>
+         <person xml:id="musset_alfred_de">
+            <persName><forename>Alfred</forename><nameLink>de</nameLink><surname>Musset</surname></persName>
+            <note>Poète, dramaturge et romancier français né en 1810 à Paris, France, et mort en
+               1857 à Paris, France.</note>
+         </person>
+         <person xml:id="mercereau_jack">
+            <persName><forename>Jack</forename><surname>Mercereau</surname></persName>
+            <note>Journaliste pour Paris-Journal</note>
+         </person>
+         <person xml:id="bataille_henry">
+            <persName><forename>Henry</forename><surname>Bataille</surname></persName>
+            <note>Dramaturge, poète et lithographe français né en 1872 à Nîmes, France, et mort en
+               1922 à Rueil-Malmaison, France.</note>
+         </person>
+         <person xml:id="cappatti_louis">
+            <persName><forename>Louis</forename><surname>Cappatti</surname></persName>
+            <note>H>omme de lettres, historien, critique d'art français, né en 1886 à la
+               Trinité-Victor, France, et mort en 1966 à Nice, France.</note>
+         </person>
+      </listPerson>
+      <listPlace>
+         <place>
+            <country xml:id="france">France</country>
+            <placeName xml:id="paris">Paris</placeName>
+            <placeName xml:id="boulevard_saint_germain">Boulevard Saint-Germain</placeName>
+         </place>
+         <place>
+            <country>France</country>
+            <placeName xml:id="nice">Nice</placeName>
+            <placeName xml:id="quai_félix_faure">Quai Félix-Faure</placeName>
+            <placeName xml:id="rue_gioffredo">Rue Gioffredo</placeName>
+         </place>
+         <place>
+            <country>République Tchèque</country>
+            <placeName xml:id="prague">Prague</placeName>
+         </place>
+         <place>
+            <country>Pays-Bas</country>
+            <placeName xml:id="amsterdam">Amsterdam</placeName>
+         </place>
+         <place>
+            <country>Royaume-Uni</country>
+            <placeName xml:id="londres">Londres</placeName>
+         </place>
+         <place>
+            <country>Ukraine</country>
+            <placeName xml:id="ukraine">Ukraine</placeName>
+         </place>
+      </listPlace>
+      <listBibl>
+         <head>Références bibliographiques</head>
+         <listBibl>
+            <listBibl>
+               <head>Références à Alcools (1913)</head>
+               <bibl type="poetry" xml:id="alcools">
+                  <title>Alcools (1913)</title>
+                  <relatedItem>
+                     <listBibl>
+                        <bibl><title type="poem" xml:id="vendémiaire">Vendémiaire</title></bibl>
+                        <bibl><title type="poem" xml:id="zone">Zone</title></bibl>
+                        <bibl><title type="poem" xml:id="la_maison_des_morts">La Maison des
+                           Morts</title></bibl>
+                        <bibl><title type="poem" xml:id="l_ermite">L'Ermite</title></bibl>
+                        <bibl><title type="poem" xml:id="l_adieu">L'Adieu</title></bibl>
+                     </listBibl>
+                  </relatedItem>
+               </bibl>
+            </listBibl>
+            <listBibl>
+               <head>Références littéraires</head>
+               <listBibl>
+                  <bibl type="poetry" xml:id="floraison_des_eaux"><title>La floraison des
+                     eaux</title>
+                     <author>Guy Lavaud</author>
+                     <editor>Bibliothèque de l'Occident</editor>
+                     <pubPlace>Paris</pubPlace>
+                     <date when="1907">1907</date></bibl>
+                  <bibl type="poetry" xml:id="du_livre_de_la_mort"><title>Du livre de la
+                     mort</title>
+                     <author>Guy Lavaud</author>
+                     <editor>La Phalange</editor>
+                     <pubPlace>Paris</pubPlace>
+                     <date when="1908">1908</date></bibl>
+                  <bibl type="literary_criticism" xml:id="les_disciplines"><title>Les disciplines :
+                     nécessité littéraire et sociale d'une renaissance classique</title>
+                     <author>Henri Clouard</author>
+                     <editor><name>M. Rivière</name></editor>
+                     <pubPlace>Paris</pubPlace>
+                     <date when="1913">1913</date></bibl>
+                  <bibl type="poem" xml:id="les_fiançailles"><title>Les Fiançailles</title>
+                     <author>Guillaume Apollinaire</author>
+                     <date when="1908">1908</date></bibl>
+                  <bibl type="fables" xml:id="fables_d_ésope"><title>Fables d'Ésope</title>
+                     <author>Esope</author>
+                     <date>VIIe siècle av. J.-C. - VIe siècle av. J.-C.</date>
+                  </bibl>
+               </listBibl>
+            </listBibl>
+            <listBibl>
+               <head>Références presse</head>
+               <listBibl>
+                  <bibl type="literary_magazine" xml:id="la_phalange"><title>La Phalange</title>
+                     <note>Revue littéraire dirigée par Jean Royère, de 1906 à 1939.</note></bibl>
+                  <bibl type="journal" xml:id="la_démocratie_sociale"><title>La démocratie
+                     sociale</title></bibl>
+                  <bibl type="journal" xml:id="echo_littéraire_du_boulevard"><title>Echo Littéraire
+                     du Boulevard</title></bibl>
+                  <bibl type="journal" xml:id="revue_critique"><title>La Revue
+                     Critique</title></bibl>
+                  <bibl type="journal" xml:id="paris-midi"><title>Paris-Midi</title></bibl>
+                  <bibl type="journal" xml:id="le_mercure_de_france"><title>Le Mercure de
+                     France</title>
+                     <note>Revue française fondée en 1672 et disparue en 1965.</note></bibl>
+                  <bibl type="journal" xml:id="paris-journal"><title>Paris-Journal</title></bibl>
+                  <bibl type="journal" xml:id="le_petit_niçois"><title>Le Petit
+                     Niçois</title></bibl>
+               </listBibl>
+            </listBibl>
+         </listBibl>
+      </listBibl>
+   </standOff>
+</TEI>


### PR DESCRIPTION
Bonjour !

J'ai essayé de faire un encodage avec ```<group>``` avec la doc TEI des articles du dossier de presse que j'encode actuellement, pour voir ce que ça donne. 

@PaulineChauvet est-ce comme ça que tu envisageais l'encodage avec ```<group>``` ? Comme tu me l'as précisé dans la PR #45 , je n'ai pas utilisé de msDesc. J'ai également fait une ébauche du ```<front>```, qui peut éventuellement être amélioré. :) 

N'ayant pas encore travaillé sur le ```<teiHeader>```, il est absent pour le moment.

Je précise que les encodages d'article ne sont pas définitifs et encore en travaux. 