### PR TITLE
Exemple encodage group pointeurs

### DIFF
--- a/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
+++ b/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Sept poèmes d'Alcools</title>
+            <author>Guillaume Apollinaire</author>
+         </titleStmt>
+         <publicationStmt>
+            <p>Recueil de versions préparatoires édité dans le cadre d'un exercice évalué (Projet Github) à l'école nationale des Chartes.</p>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <country>France</country>
+                  <repository>Bibliothèque nationale de France. Département des Manuscrits.</repository>
+                  <altIdentifier>
+                     <idno>NAF 25608</idno>
+                  </altIdentifier>
+                  <altIdentifier>
+                     <idno>ark:/12148/btv1b52505641f</idno>
+                  </altIdentifier>
+               </msIdentifier>
+               <msContents>
+                  <msItemStruct n="1" xml:lang="fr" xml:id="le_pont_mirabeau">
+                     <locus>f.1</locus>
+                     <title>Le Pont Mirabeau</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="2" xml:lang="fr" xml:id="la_chanson_du_mal_aime">
+                     <locus>ff. 2-14</locus>
+                     <title>La chanson du Mal-Aimé</title>
+                     <note>Manuscrit autographe. Un premier feuillet correspondant aux strophes 1 à 4 est manquant. La fin du poème manque aussi (depuis la strophe 46), à l'exception de la strophe 57. Au verso, fragments manuscrits de <title>La femme assise</title>.</note>
+                  </msItemStruct>
+                  <msItemStruct n="3" xml:lang="fr" xml:id="marizibill">
+                     <locus>f. 15</locus>
+                     <title>Marizibill</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="4" xml:lang="fr" xml:id="mai">
+                     <locus>f. 16</locus>
+                     <title>Mai.</title>
+                     <note>Manuscrit autographe signé et daté de Leutesdorf, mai 1902. Avec des indications manuscrites en vue de l'impression dans "Vers et prose".</note>
+                  </msItemStruct>
+                  <msItemStruct n="5" xml:lang="fr" xml:id="les_cloches">
+                     <locus>f. 17</locus>
+                     <title>Les Cloches</title>
+                     <note>Manuscrit autographe signé et daté de Oberpleis, mai 1902.</note>
+                  </msItemStruct>
+                  <msItemStruct n="6" xml:lang="fr" xml:id="p_1909">
+                     <locus>ff. 18-19</locus>
+                     <title>1909</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="7" xml:lang="fr" xml:id="a_la_sante">
+                     <locus>ff. 20-23</locus>
+                     <title>A la santé</title>
+                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title>La Femme assise</title></note>
+                  </msItemStruct>
+               </msContents>
+               <physDesc>   
+                  <objectDesc form="codex">
+                     <supportDesc>
+                        <support>Papier</support>
+                        <extent>
+                           <width unit="mm">250</width>
+                           <height unit="mm">220</height>
+                        </extent>
+                        <foliation>23 feuillets</foliation>        
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <p>Reliure demi-chagrin bleu roi</p>
+                  </bindingDesc>
+               </physDesc> 
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <creation>
+            <date>1901-1902</date>
+            <lang xml:lang="fre"/>
+         </creation>
+      </profileDesc>
+   </teiHeader>
+  <text>
+     <front>
+        <docTitle>
+           <titlePart>Apollinaire</titlePart>
+           <titlePart>Sept poèmes d'Alcools</titlePart>
+        </docTitle>
+     </front>
+     <group>
+        <text>
+           <front>
+              <docTitle ref="#les_cloches">
+                 <titlePart>Les Cloches</titlePart>
+              </docTitle>
+           </front>
+           <body>
+              <div type="poeme" facs="https://gallicabnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+                 <head>Les Cloches</head>
+                 <lg type="quintil" n="1">
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                 </lg> 
+              </div>
+           </body>
+        </text>
+      <text>
+         <front>
+            <docTitle ref="#p_1909">
+               <titlePart>1909</titlePart>
+             </docTitle>
+         </front>
+      <body>
+         <msDesc>
+            <msIdentifier><repository>Bibliothèque nationale de France</repository></msIdentifier>
+            <physDesc>   
+            <objectDesc>
+               <supportDesc>
+               <extent>1 page</extent>        
+               </supportDesc>
+               <layoutDesc>
+                  <layout columns="1">Strophes séparées par un saut de ligne et disposées sur une seule colonne.</layout>
+               </layoutDesc>
+            </objectDesc>
+             </physDesc> 
+         </msDesc>
+         <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+            <head>1909 <add place="beside">88:</add></head>
+            <lg type="quintil" n="1">
+               <l>La dame avait une robe</l>
+               <l>En ottoman violine</l>
+               <l>Et sa tunique brodée d’or</l>
+               <l>Était composée de deux panneaux</l>
+               <l> S’attachant sur l’épaule.</l>
+            </lg>
+            <lg type="quintil" n="2"> 
+               <l>Les yeux dansants comme des anges</l>
+               <l>Elle riait, elle riait</l>
+               <l>Elle avait un visage aux couleurs de France</l>
+               <l>Les yeux bleus, les dents blanches et les lèvres très rouges</l> 
+               <l>Elle avait un visage aux couleurs de France.</l>
+            </lg>
+            <lg type="septain" n="1"> 
+               <l>  Elle était décolletée en rond</l>
+               <l>Et coiffée à la Récamier</l>
+               <l>Avec de beaux bras nus.</l>
+               <l><delSpan spanTo="#l7" quantity="4" unit="lines"/>Pareils au col candide</l> 
+               <l>De l’amant divin et ailé</l>
+               <l>De cette Léda solitaire</l>
+               <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
+            </lg>
+            <lg type="monostiche" n="1">
+               <l> - N’entendra-t-on jamais sonner minuit <del><gap quantity="1" unit="word" reason="illegible"/></del></l>
+            </lg>
+             <lg type="quatrain" n="1"> 
+                <l>La dame en robe d’ottoman violine</l>
+                <l>Et en tunique brodée d’or</l>
+                <l> Décolletée en rond</l> 
+                <l><subst><add>Promène</add><del>promenait</del></subst> ses boucles</l>
+            </lg>
+            <lg type="quatrain" n="2"> 
+               <l>Son bandeau d’or</l>
+               <l>Et traînant ses petits souliers à boucles</l>
+               <l>Elle était si belle</l> 
+               <l>Que je n’aurais pas osé l’aimer.</l>
+            </lg>
+            <lg type="quintil" n="1">
+               <l>J’aimais les flammes atroces dans les quartiers énormes</l>
+               <l>Où naissaient chaque jour quelques êtres nouveaux</l>
+               <l>Le fer était leur sang, la flamme leur cerveau.</l>
+               <l>J’aimais, j’aimais le peuple habile des machines</l>
+               <l> de luxe et la beauté ne sont que son écume.</l>
+            </lg>
+            <lg type="tercet" n="1">
+               <l>Cette femme était si belle</l>
+               <l>Que je n’aurais pas osé l’aimer (rayé)</l>
+               <l>qu’elle me faisait peur.</l>
+            </lg>
+         </div>
+      </body>
+      </text>
+     </group>
+  </text>
+</TEI>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
@@ -134,7 +134,6 @@
              </physDesc> 
          </msDesc>
          <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
-            <head>1909 <add place="beside">88:</add></head>
             <lg type="quintil" n="1">
                <l>La dame avait une robe</l>
                <l>En ottoman violine</l>

--- a/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
+++ b/poèmesmanuscrits/Echantillon_Encodage_PoemesManuscrits/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Sept poèmes d'Alcools</title>
+            <author>Guillaume Apollinaire</author>
+         </titleStmt>
+         <publicationStmt>
+            <p>Recueil de versions préparatoires édité dans le cadre d'un exercice évalué (Projet Github) à l'école nationale des Chartes.</p>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <country>France</country>
+                  <repository>Bibliothèque nationale de France. Département des Manuscrits.</repository>
+                  <altIdentifier>
+                     <idno>NAF 25608</idno>
+                  </altIdentifier>
+                  <altIdentifier>
+                     <idno>ark:/12148/btv1b52505641f</idno>
+                  </altIdentifier>
+               </msIdentifier>
+               <msContents>
+                  <msItemStruct n="1" xml:lang="fr" xml:id="le_pont_mirabeau">
+                     <locus>f.1</locus>
+                     <title>Le Pont Mirabeau</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="2" xml:lang="fr" xml:id="la_chanson_du_mal_aime">
+                     <locus>ff. 2-14</locus>
+                     <title>La chanson du Mal-Aimé</title>
+                     <note>Manuscrit autographe. Un premier feuillet correspondant aux strophes 1 à 4 est manquant. La fin du poème manque aussi (depuis la strophe 46), à l'exception de la strophe 57. Au verso, fragments manuscrits de <title>La femme assise</title>.</note>
+                  </msItemStruct>
+                  <msItemStruct n="3" xml:lang="fr" xml:id="marizibill">
+                     <locus>f. 15</locus>
+                     <title>Marizibill</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="4" xml:lang="fr" xml:id="mai">
+                     <locus>f. 16</locus>
+                     <title>Mai.</title>
+                     <note>Manuscrit autographe signé et daté de Leutesdorf, mai 1902. Avec des indications manuscrites en vue de l'impression dans "Vers et prose".</note>
+                  </msItemStruct>
+                  <msItemStruct n="5" xml:lang="fr" xml:id="les_cloches">
+                     <locus>f. 17</locus>
+                     <title>Les Cloches</title>
+                     <note>Manuscrit autographe signé et daté de Oberpleis, mai 1902.</note>
+                  </msItemStruct>
+                  <msItemStruct n="6" xml:lang="fr" xml:id="p_1909">
+                     <locus>ff. 18-19</locus>
+                     <title>1909</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="7" xml:lang="fr" xml:id="a_la_sante">
+                     <locus>ff. 20-23</locus>
+                     <title>A la santé</title>
+                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title>La Femme assise</title></note>
+                  </msItemStruct>
+               </msContents>
+               <physDesc>   
+                  <objectDesc form="codex">
+                     <supportDesc>
+                        <support>Papier</support>
+                        <extent>
+                           <width unit="mm">250</width>
+                           <height unit="mm">220</height>
+                        </extent>
+                        <foliation>23 feuillets</foliation>        
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <p>Reliure demi-chagrin bleu roi</p>
+                  </bindingDesc>
+               </physDesc> 
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <creation>
+            <date>1901-1902</date>
+            <lang xml:lang="fre"/>
+         </creation>
+      </profileDesc>
+   </teiHeader>
+  <text>
+     <front>
+        <docTitle>
+           <titlePart>Apollinaire</titlePart>
+           <titlePart>Sept poèmes d'Alcools</titlePart>
+        </docTitle>
+     </front>
+     <group>
+        <text>
+           <front>
+              <docTitle ref="#les_cloches">
+                 <titlePart>Les Cloches</titlePart>
+              </docTitle>
+           </front>
+           <body>
+              <div type="poeme" facs="https://gallicabnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+                 <head>Les Cloches</head>
+                 <lg type="quintil" n="1">
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                 </lg> 
+              </div>
+           </body>
+        </text>
+      <text>
+         <front>
+            <docTitle ref="#p_1909">
+               <titlePart>1909</titlePart>
+             </docTitle>
+         </front>
+      <body>
+         <msDesc>
+            <msIdentifier><repository>Bibliothèque nationale de France</repository></msIdentifier>
+            <physDesc>   
+            <objectDesc>
+               <supportDesc>
+               <extent>1 page</extent>        
+               </supportDesc>
+               <layoutDesc>
+                  <layout columns="1">Strophes séparées par un saut de ligne et disposées sur une seule colonne.</layout>
+               </layoutDesc>
+            </objectDesc>
+             </physDesc> 
+         </msDesc>
+         <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+            <head>1909 <add place="beside">88:</add></head>
+            <lg type="quintil" n="1">
+               <l>La dame avait une robe</l>
+               <l>En ottoman violine</l>
+               <l>Et sa tunique brodée d’or</l>
+               <l>Était composée de deux panneaux</l>
+               <l> S’attachant sur l’épaule.</l>
+            </lg>
+            <lg type="quintil" n="2"> 
+               <l>Les yeux dansants comme des anges</l>
+               <l>Elle riait, elle riait</l>
+               <l>Elle avait un visage aux couleurs de France</l>
+               <l>Les yeux bleus, les dents blanches et les lèvres très rouges</l> 
+               <l>Elle avait un visage aux couleurs de France.</l>
+            </lg>
+            <lg type="septain" n="1"> 
+               <l>  Elle était décolletée en rond</l>
+               <l>Et coiffée à la Récamier</l>
+               <l>Avec de beaux bras nus.</l>
+               <l><delSpan spanTo="#l7" quantity="4" unit="lines"/>Pareils au col candide</l> 
+               <l>De l’amant divin et ailé</l>
+               <l>De cette Léda solitaire</l>
+               <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
+            </lg>
+            <lg type="monostiche" n="1">
+               <l> - N’entendra-t-on jamais sonner minuit <del><gap quantity="1" unit="word" reason="illegible"/></del></l>
+            </lg>
+             <lg type="quatrain" n="1"> 
+                <l>La dame en robe d’ottoman violine</l>
+                <l>Et en tunique brodée d’or</l>
+                <l> Décolletée en rond</l> 
+                <l><subst><add>Promène</add><del>promenait</del></subst> ses boucles</l>
+            </lg>
+            <lg type="quatrain" n="2"> 
+               <l>Son bandeau d’or</l>
+               <l>Et traînant ses petits souliers à boucles</l>
+               <l>Elle était si belle</l> 
+               <l>Que je n’aurais pas osé l’aimer.</l>
+            </lg>
+            <lg type="quintil" n="1">
+               <l>J’aimais les flammes atroces dans les quartiers énormes</l>
+               <l>Où naissaient chaque jour quelques êtres nouveaux</l>
+               <l>Le fer était leur sang, la flamme leur cerveau.</l>
+               <l>J’aimais, j’aimais le peuple habile des machines</l>
+               <l> de luxe et la beauté ne sont que son écume.</l>
+            </lg>
+            <lg type="tercet" n="1">
+               <l>Cette femme était si belle</l>
+               <l>Que je n’aurais pas osé l’aimer (rayé)</l>
+               <l>qu’elle me faisait peur.</l>
+            </lg>
+         </div>
+      </body>
+      </text>
+     </group>
+  </text>
+</TEI>

--- a/poèmesmanuscrits/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
+++ b/poèmesmanuscrits/ExempleElementGroup_FrontAbrege_pointeurs.VersionGenetique.xml
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
+	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+   <teiHeader>
+      <fileDesc>
+         <titleStmt>
+            <title>Sept poèmes d'Alcools</title>
+            <author>Guillaume Apollinaire</author>
+         </titleStmt>
+         <publicationStmt>
+            <p>Recueil de versions préparatoires édité dans le cadre d'un exercice évalué (Projet Github) à l'école nationale des Chartes.</p>
+         </publicationStmt>
+         <sourceDesc>
+            <msDesc>
+               <msIdentifier>
+                  <country>France</country>
+                  <repository>Bibliothèque nationale de France. Département des Manuscrits.</repository>
+                  <altIdentifier>
+                     <idno>NAF 25608</idno>
+                  </altIdentifier>
+                  <altIdentifier>
+                     <idno>ark:/12148/btv1b52505641f</idno>
+                  </altIdentifier>
+               </msIdentifier>
+               <msContents>
+                  <msItemStruct n="1" xml:lang="fr" xml:id="le_pont_mirabeau">
+                     <locus>f.1</locus>
+                     <title>Le Pont Mirabeau</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="2" xml:lang="fr" xml:id="la_chanson_du_mal_aime">
+                     <locus>ff. 2-14</locus>
+                     <title>La chanson du Mal-Aimé</title>
+                     <note>Manuscrit autographe. Un premier feuillet correspondant aux strophes 1 à 4 est manquant. La fin du poème manque aussi (depuis la strophe 46), à l'exception de la strophe 57. Au verso, fragments manuscrits de <title>La femme assise</title>.</note>
+                  </msItemStruct>
+                  <msItemStruct n="3" xml:lang="fr" xml:id="marizibill">
+                     <locus>f. 15</locus>
+                     <title>Marizibill</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="4" xml:lang="fr" xml:id="mai">
+                     <locus>f. 16</locus>
+                     <title>Mai.</title>
+                     <note>Manuscrit autographe signé et daté de Leutesdorf, mai 1902. Avec des indications manuscrites en vue de l'impression dans "Vers et prose".</note>
+                  </msItemStruct>
+                  <msItemStruct n="5" xml:lang="fr" xml:id="les_cloches">
+                     <locus>f. 17</locus>
+                     <title>Les Cloches</title>
+                     <note>Manuscrit autographe signé et daté de Oberpleis, mai 1902.</note>
+                  </msItemStruct>
+                  <msItemStruct n="6" xml:lang="fr" xml:id="p_1909">
+                     <locus>ff. 18-19</locus>
+                     <title>1909</title>
+                     <note>Manuscrit autographe</note>
+                  </msItemStruct>
+                  <msItemStruct n="7" xml:lang="fr" xml:id="a_la_sante">
+                     <locus>ff. 20-23</locus>
+                     <title>A la santé</title>
+                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title>La Femme assise</title></note>
+                  </msItemStruct>
+               </msContents>
+               <physDesc>   
+                  <objectDesc form="codex">
+                     <supportDesc>
+                        <support>Papier</support>
+                        <extent>
+                           <width unit="mm">250</width>
+                           <height unit="mm">220</height>
+                        </extent>
+                        <foliation>23 feuillets</foliation>        
+                     </supportDesc>
+                  </objectDesc>
+                  <bindingDesc>
+                     <p>Reliure demi-chagrin bleu roi</p>
+                  </bindingDesc>
+               </physDesc> 
+            </msDesc>
+         </sourceDesc>
+      </fileDesc>
+      <profileDesc>
+         <creation>
+            <date>1901-1902</date>
+            <lang xml:lang="fre"/>
+         </creation>
+      </profileDesc>
+   </teiHeader>
+  <text>
+     <front>
+        <docTitle>
+           <titlePart>Apollinaire</titlePart>
+           <titlePart>Sept poèmes d'Alcools</titlePart>
+        </docTitle>
+     </front>
+     <group>
+        <text>
+           <front>
+              <docTitle ref="#les_cloches">
+                 <titlePart>Les Cloches</titlePart>
+              </docTitle>
+           </front>
+           <body>
+              <div type="poeme" facs="https://gallicabnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+                 <head>Les Cloches</head>
+                 <lg type="quintil" n="1">
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                    <l></l>
+                 </lg> 
+              </div>
+           </body>
+        </text>
+      <text>
+         <front>
+            <docTitle ref="#p_1909">
+               <titlePart>1909</titlePart>
+             </docTitle>
+         </front>
+      <body>
+         <msDesc>
+            <msIdentifier><repository>Bibliothèque nationale de France</repository></msIdentifier>
+            <physDesc>   
+            <objectDesc>
+               <supportDesc>
+               <extent>1 page</extent>        
+               </supportDesc>
+               <layoutDesc>
+                  <layout columns="1">Strophes séparées par un saut de ligne et disposées sur une seule colonne.</layout>
+               </layoutDesc>
+            </objectDesc>
+             </physDesc> 
+         </msDesc>
+         <div type="poeme" facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f63.item.r=Manuscrit%20Apollinaire">
+            <head>1909 <add place="beside">88:</add></head>
+            <lg type="quintil" n="1">
+               <l>La dame avait une robe</l>
+               <l>En ottoman violine</l>
+               <l>Et sa tunique brodée d’or</l>
+               <l>Était composée de deux panneaux</l>
+               <l> S’attachant sur l’épaule.</l>
+            </lg>
+            <lg type="quintil" n="2"> 
+               <l>Les yeux dansants comme des anges</l>
+               <l>Elle riait, elle riait</l>
+               <l>Elle avait un visage aux couleurs de France</l>
+               <l>Les yeux bleus, les dents blanches et les lèvres très rouges</l> 
+               <l>Elle avait un visage aux couleurs de France.</l>
+            </lg>
+            <lg type="septain" n="1"> 
+               <l>  Elle était décolletée en rond</l>
+               <l>Et coiffée à la Récamier</l>
+               <l>Avec de beaux bras nus.</l>
+               <l><delSpan spanTo="#l7" quantity="4" unit="lines"/>Pareils au col candide</l> 
+               <l>De l’amant divin et ailé</l>
+               <l>De cette Léda solitaire</l>
+               <l>Que deux étoiles appellent ma mère<anchor xml:id="l7"/></l>
+            </lg>
+            <lg type="monostiche" n="1">
+               <l> - N’entendra-t-on jamais sonner minuit <del><gap quantity="1" unit="word" reason="illegible"/></del></l>
+            </lg>
+             <lg type="quatrain" n="1"> 
+                <l>La dame en robe d’ottoman violine</l>
+                <l>Et en tunique brodée d’or</l>
+                <l> Décolletée en rond</l> 
+                <l><subst><add>Promène</add><del>promenait</del></subst> ses boucles</l>
+            </lg>
+            <lg type="quatrain" n="2"> 
+               <l>Son bandeau d’or</l>
+               <l>Et traînant ses petits souliers à boucles</l>
+               <l>Elle était si belle</l> 
+               <l>Que je n’aurais pas osé l’aimer.</l>
+            </lg>
+            <lg type="quintil" n="1">
+               <l>J’aimais les flammes atroces dans les quartiers énormes</l>
+               <l>Où naissaient chaque jour quelques êtres nouveaux</l>
+               <l>Le fer était leur sang, la flamme leur cerveau.</l>
+               <l>J’aimais, j’aimais le peuple habile des machines</l>
+               <l> de luxe et la beauté ne sont que son écume.</l>
+            </lg>
+            <lg type="tercet" n="1">
+               <l>Cette femme était si belle</l>
+               <l>Que je n’aurais pas osé l’aimer (rayé)</l>
+               <l>qu’elle me faisait peur.</l>
+            </lg>
+         </div>
+      </body>
+      </text>
+     </group>
+  </text>
+</TEI>


### PR DESCRIPTION
Bonjour à tous,

Voici mon exemple d'encodage pour le recueil des sept poèmes _d'_Alcools__qui réunit ma proposition pour le teiHeader corrigé selon vos remarques ainsi que l'utilisation de Group avec un élément "front" réduit grâce aux pointeurs. Ces derniers renvoient aux identifiants des différents poèmes présentés dans le teiHearder.
Il est impossible de mettre un attribut-pointeur @ref dans un élément front. Il n'est possible de le placer que dans un élément docTitle qui lui-même induit obligatoirement un élément enfant "titlePart". Ainsi, la partie "front" telle que présentée dans mon exemple est la plus minimale qui soit. 