### PR TITLE
Amélioration de l'encodage du recueil de poèmes manuscrits

### DIFF
--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -970,7 +970,7 @@
                         <l> Décolletée en rond</l>
                         <l><subst>
                               <del unit="word" quantity="1" rend="overtyped">promenait</del>
-                              <add>Promène</add>
+                              <add unit="word" quantity="1" rend="overtyped">Promène</add>
                            </subst> ses boucles</l>
                      </lg>
                   </div>
@@ -1276,7 +1276,8 @@
                         <l><subst>
                               <del unit="line" quantity="1" rend="strikethrough">Une mouche sur mon
                                  papier à pas menus</del>
-                              <add>Une mouche sur le papier à pas menus</add>
+                              <add unit="line" quantity="1" rend="align(below)">Une mouche sur le
+                                 papier à pas menus</add>
                            </subst></l>
                         <l>Parcourt mes lignes inégales.</l>
                         <l><subst>
@@ -1286,7 +1287,8 @@
                                  couloirs</del>
                               <del unit="line" quantity="1" rend="strikethrough">Cette chaise
                                  illisible où je m'assieds</del>
-                              <add>Que deviendrai-je ? ô Dieu qui connais ma douleur</add>
+                              <add unit="line" quantity="1" rend="align(below)">Que deviendrai-je ?
+                                 ô Dieu qui connais ma douleur</add>
                            </subst></l>
                         <figure rend="align(margin)">
                            <figDesc>8 A la santé Alcools 181</figDesc>
@@ -1391,10 +1393,10 @@
                </docTitle>
             </front>
             <body>
-               <div type="poeme" corresp="http://gallica.bnf.fr/ark:/12148/bpt6k1co083760/f150.item">
+               <div type="poeme" corresp="http://gallica.bnf.fr/ark:/12148/bpt6k1co083760/f75.item">
                   <div type="page" n="23">
                      <pb type="recto"
-                        facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f73.item.r=Manuscrit%20Apollinaire"/>
+                        facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f75.item.r=Manuscrit%20Apollinaire"/>
                      <p><add rend="align(top)">23</add></p>
                      <lg type="quatrain" n="3">
                         <delSpan spanTo="#p_23a" unit="line" quantity="28" rend="strikethrough"/>
@@ -1472,8 +1474,9 @@
                         <l>que lentement <add rend="align(above)">passent</add> les heures,</l>
                         <l><subst>
                               <del unit="line" quantity="1" rend="overtyped">Et toutes les heu</del>
-                              <add>comme passe un enterrement <del unit="char" quantity="1"
-                                    rend="strikethrough">!</del> !</add>
+                              <add unit="line" quantity="1" rend="align(below)">comme passe un
+                                 enterrement <del unit="char" quantity="1" rend="strikethrough"
+                                    >!</del> !</add>
                            </subst></l>
                         <l>Tu pleureras l'heure où tu pleures</l>
                         <l>qui passera trop vitement</l>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -671,7 +671,7 @@
                         <l>Poisson <subst>
                               <del rend="overtyped"><gap quantity="1" unit="word" reason="illegible"
                                  /></del>
-                              <add>pourri</add>
+                           <add quantity="1" unit="word" rend="overtyped">pourri</add>
                            </subst> de Salonique,</l>
                         <l>Gemmes de cabochons affreux</l>
                         <l>Des yeux creuvés à coup de piques</l>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -677,7 +677,7 @@
                         <l>Des yeux creuvés à coup de piques</l>
                         <l>Ta <subst>
                               <del quantity="2" unit="char" rend="overtyped">fi</del>
-                              <add>pourri</add>
+                              <add>mère</add>
                            </subst> fit un pet foireux</l>
                         <l>Et tu naquis de sa colique</l>
                         <l><del quantity="3" unit="word" rend="strikethrough">Ne réponds

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
-	schematypens="http://purl.oclc.org/dsdl/schematron"?>
-
 <?xml-model href="out/poeme_ODD.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="out/poeme_ODD.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
       <fileDesc>
@@ -67,7 +65,7 @@
                   <msItemStruct n="7" xml:lang="fr" xml:id="a_la_sante">
                      <locus>ff. 20-23</locus>
                      <title>A la santé</title>
-                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title>La
+                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title xml:id="la_femme_assise">La
                            Femme assise</title></note>
                   </msItemStruct>
                </msContents>
@@ -1083,7 +1081,7 @@
          </text>
          <text>
             <front>
-               <docTitle>
+               <docTitle ref="#la_femme_assise">
                   <titlePart>La Femme Assise. Fragments.</titlePart>
                </docTitle>
             </front>
@@ -1207,7 +1205,7 @@
          </text>
          <text>
             <front>
-               <docTitle>
+               <docTitle ref="#la_femme_assise">
                   <titlePart>La Femme Assise. Fragments.</titlePart>
                </docTitle>
             </front>
@@ -1336,7 +1334,7 @@
          </text>
          <text>
             <front>
-               <docTitle>
+               <docTitle ref="#la_femme_assise">
                   <titlePart>La Femme Assise. Fragments.</titlePart>
                </docTitle>
             </front>
@@ -1490,7 +1488,7 @@
          </text>
          <text>
             <front>
-               <docTitle>
+               <docTitle ref="#la_femme_assise">
                   <titlePart>La Femme Assise. Fragments.</titlePart>
                </docTitle>
             </front>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -74,16 +74,16 @@
                   <msItemStruct n="7" xml:lang="fr" xml:id="a_la_sante">
                      <locus>ff. 20-23</locus>
                      <title>A la santé</title>
-                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title xml:id="la_femme_assise">La
-                           Femme assise</title></note>
+                     <note>Manuscrit de premier jet. Au verso, fragments manuscrits de <title
+                           xml:id="la_femme_assise">La Femme assise</title></note>
                   </msItemStruct>
                </msContents>
                <physDesc>
                   <objectDesc form="codex">
                      <supportDesc>
                         <support>Papier, <stamp>utilisation quasi-systématique d'une estampille sur
-                           laquelle on lit "Bibliothèque Nationale MSS" sur les pages du
-                           document.</stamp></support>
+                              laquelle on lit "Bibliothèque Nationale MSS" sur les pages du
+                              document.</stamp></support>
                         <extent>
                            <width unit="mm">250</width>
                            <height unit="mm">220</height>
@@ -677,7 +677,7 @@
                         <l>Des yeux creuvés à coup de piques</l>
                         <l>Ta <subst>
                               <del quantity="2" unit="char" rend="overtyped">fi</del>
-                              <add>mère</add>
+                              <add quantity="2" unit="char" rend="overtyped">mère</add>
                            </subst> fit un pet foireux</l>
                         <l>Et tu naquis de sa colique</l>
                         <l><del quantity="3" unit="word" rend="strikethrough">Ne réponds
@@ -967,35 +967,35 @@
                         <l> Décolletée en rond</l>
                         <l><subst>
                               <del unit="word" quantity="1" rend="overtyped">promenait</del>
-                              <add>Promène</add>                              
+                              <add>Promène</add>
                            </subst> ses boucles</l>
                      </lg>
                   </div>
-                     <div type="page" n="19">
-                        <pb type="recto"
-                           facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f65.item.r=Manuscrit%20Apollinaire"/>
-                        <p><add rend="align(top)">19</add></p>
-                        <lg type="quatrain" n="2">
-                           <l>Son bandeau d’or</l>
-                           <l>Et traînant ses petits souliers à boucles</l>
-                           <l>Elle était si belle</l>
-                           <l>Que je n’aurais pas osé l’aimer.</l>
-                        </lg>
-                        <lg type="quintil" n="3">
-                           <l>J’aimais les flammes atroces dans les quartiers énormes</l>
-                           <l>Où naissaient chaque jour quelques êtres nouveaux</l>
-                           <l>Le fer était leur sang, la flamme leur cerveau.</l>
-                           <l>J’aimais, j’aimais le peuple habile des machines</l>
-                           <l> de luxe et la beauté ne sont que son écume.</l>
-                        </lg>
-                        <lg type="distique" n="1">
-                           <l>Cette femme était si belle</l>
-                           <l><del unit="word" quantity="8" rend="strikethrough">Que je n’aurais pas
-                                 osé l’aimer</del></l>
-                           <l>qu’elle me faisait peur.</l>
-                        </lg>
-                     </div>
+                  <div type="page" n="19">
+                     <pb type="recto"
+                        facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f65.item.r=Manuscrit%20Apollinaire"/>
+                     <p><add rend="align(top)">19</add></p>
+                     <lg type="quatrain" n="2">
+                        <l>Son bandeau d’or</l>
+                        <l>Et traînant ses petits souliers à boucles</l>
+                        <l>Elle était si belle</l>
+                        <l>Que je n’aurais pas osé l’aimer.</l>
+                     </lg>
+                     <lg type="quintil" n="3">
+                        <l>J’aimais les flammes atroces dans les quartiers énormes</l>
+                        <l>Où naissaient chaque jour quelques êtres nouveaux</l>
+                        <l>Le fer était leur sang, la flamme leur cerveau.</l>
+                        <l>J’aimais, j’aimais le peuple habile des machines</l>
+                        <l> de luxe et la beauté ne sont que son écume.</l>
+                     </lg>
+                     <lg type="distique" n="1">
+                        <l>Cette femme était si belle</l>
+                        <l><del unit="word" quantity="8" rend="strikethrough">Que je n’aurais pas
+                              osé l’aimer</del></l>
+                        <l>qu’elle me faisait peur.</l>
+                     </lg>
                   </div>
+               </div>
             </body>
          </text>
          <text>
@@ -1155,8 +1155,7 @@
                            <extent>1 page</extent>
                         </supportDesc>
                         <layoutDesc>
-                           <layout columns="1">Vers écrits sur une seule
-                              colonne.</layout>
+                           <layout columns="1">Vers écrits sur une seule colonne.</layout>
                         </layoutDesc>
                      </objectDesc>
                   </physDesc>
@@ -1265,7 +1264,7 @@
                   <div type="page" n="22">
                      <pb type="recto"
                         facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f73.item.r=Manuscrit%20Apollinaire"/>
-                     <p><add rend="align(top)">22</add></p>          
+                     <p><add rend="align(top)">22</add></p>
                      <lg type="huitain" n="3">
                         <delSpan spanTo="#p_22a" unit="line" quantity="28" rend="strikethrough"/>
                         <l>Que je m'ennuie entre ces quatre murs tous nus</l>
@@ -1297,11 +1296,11 @@
                      <lg type="quatrain" n="1">
                         <delSpan spanTo="#p_22b" unit="line" quantity="3" rend="strikethrough"/>
                         <l>Mais les couloirs où crie</l>
-                           <l>Dans les couloirs</l>
+                        <l>Dans les couloirs</l>
                         <l>Cette chaise illisible où je m'assieds</l>
-                           <anchor xml:id="p_22b"/>
-                        <l><add xml:id="a1" rend="align(below)">Que deviendrai-je ? ô Dieu qui connais ma
-                           douleur</add></l>
+                        <anchor xml:id="p_22b"/>
+                        <l><add xml:id="a1" rend="align(below)">Que deviendrai-je ? ô Dieu qui
+                              connais ma douleur</add></l>
                         <substJoin target="#p_22b #a1"/>
                         <l>L'amour qui m'acccompagne</l>
                         <l>Prends en pitié surtout ma débile raison</l>
@@ -1393,21 +1392,18 @@
                   <div type="page" n="23">
                      <pb type="recto"
                         facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f73.item.r=Manuscrit%20Apollinaire"/>
-                     <p><add rend="align(top)">23</add></p>                     
+                     <p><add rend="align(top)">23</add></p>
                      <lg type="quatrain" n="3">
                         <delSpan spanTo="#p_23a" unit="line" quantity="28" rend="strikethrough"/>
                         <delSpan spanTo="#p_23b" unit="line" quantity="2" rend="strikethrough"/>
-                           <l>Vierge plus douce                           
-                              que le sucre</l>
-                           <l>Vierge qui m'avez
-                                 protégé</l>
-                           <anchor xml:id="p_23b"/>
-                              <l><add xml:id="a2" rend="align(below)">Et Je viens de dire un <subst>
-                                    <del unit="word" quantity="1" rend="strikethrough"
-                                       >chapelet</del>
-                                    <add rend="overtyped">rosaire</add>
-                                 </subst></add>
-                                 <substJoin target="#p_23b #a2"/></l>
+                        <l>Vierge plus douce que le sucre</l>
+                        <l>Vierge qui m'avez protégé</l>
+                        <anchor xml:id="p_23b"/>
+                        <l><add xml:id="a2" rend="align(below)">Et Je viens de dire un <subst>
+                                 <del unit="word" quantity="1" rend="strikethrough">chapelet</del>
+                                 <add rend="overtyped">rosaire</add>
+                              </subst></add>
+                           <substJoin target="#p_23b #a2"/></l>
                         <l>Avec mes doigts pour chapelet</l>
                         <l>O Vierge Sainte écoutez les</l>
                         <figure rend="align(margin)">
@@ -1455,7 +1451,8 @@
                               <del unit="word" quantity="2" rend="strikethrough">Quand moi</del>
                               <add rend="align(below)">Je suis</add>
                            </subst> Guillaume Apollinaire</l>
-                        <l><unclear unit="char" quantity="5" reason="illegible"/> d'un nom slave pour vrai nom</l>
+                        <l><unclear unit="char" quantity="5" reason="illegible"/> d'un nom slave
+                           pour vrai nom</l>
                         <l>Ma <del unit="word" quantity="2" rend="strikethrough">est <gap
                                  unit="char" quantity="2" reason="illegible"/></del> vie est triste
                            toute entière</l>
@@ -1471,10 +1468,9 @@
                         <l>Un prisonnier bien embêté</l>
                         <l>que lentement <add rend="align(above)">passent</add> les heures,</l>
                         <l><subst>
-                           <del unit="line" quantity="1" rend="overtyped">Et toutes les
-                                 heu</del>
-                              <add>comme passe un enterrement <del unit="char"
-                                    quantity="1" rend="strikethrough">!</del> !</add>
+                              <del unit="line" quantity="1" rend="overtyped">Et toutes les heu</del>
+                              <add>comme passe un enterrement <del unit="char" quantity="1"
+                                    rend="strikethrough">!</del> !</add>
                            </subst></l>
                         <l>Tu pleureras l'heure où tu pleures</l>
                         <l>qui passera trop vitement</l>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -1455,7 +1455,7 @@
                               <del unit="word" quantity="2" rend="strikethrough">Quand moi</del>
                               <add rend="align(below)">Je suis</add>
                            </subst> Guillaume Apollinaire</l>
-                        <l><unclear/> d'un nom slave pour vrai nom</l>
+                        <l><unclear unit="char" quantity="5" reason="illegible"/> d'un nom slave pour vrai nom</l>
                         <l>Ma <del unit="word" quantity="2" rend="strikethrough">est <gap
                                  unit="char" quantity="2" reason="illegible"/></del> vie est triste
                            toute entière</l>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -17,7 +17,16 @@
                <msIdentifier>
                   <country>France</country>
                   <institution>
-                     
+                     <name>Bibliothèque nationale de France</name>
+                     <stamp xml:id="estampille_bnf_1870" facs="http://bibale.irht.cnrs.fr/44365">
+                        <mentioned>Biblioth. nationale MSS</mentioned>
+                        <dimensions>
+                           <height unit="mm">12</height>
+                        </dimensions>
+                        <note>Petite estampille ovale (en hauteur) du département des manuscrits de
+                           la Bibliothèque nationale (aujourd'hui BnF) après <date when="1870"
+                              >1870</date></note>
+                     </stamp>
                   </institution>
                   <repository>BnF. Département des Manuscrits.</repository>
                   <altIdentifier>
@@ -72,15 +81,9 @@
                <physDesc>
                   <objectDesc form="codex">
                      <supportDesc>
-                        <support><stamp xml:id="estampille_bnf_1870" facs="http://bibale.irht.cnrs.fr/44365">
-                           <mentioned>Biblioth. nationale MSS</mentioned>
-                           <dimensions>
-                              <height unit="mm">12</height>
-                           </dimensions>
-                           <note>Petite estampille ovale (en hauteur) du département des manuscrits de
-                              la Bibliothèque nationale (aujourd'hui BnF) après <date when="1870"
-                                 >1870</date></note>
-                        </stamp></support>
+                        <support>Papier, <stamp>utilisation quasi-systématique d'une estampille sur
+                           laquelle on lit "Bibliothèque Nationale MSS" sur les pages du
+                           document.</stamp></support>
                         <extent>
                            <width unit="mm">250</width>
                            <height unit="mm">220</height>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -1233,7 +1233,7 @@
                            rend="strikethrough">pen</del> arrivaient en courant, rythmant leur pas
                         et le<del unit="char" quantity="2">ur</del> bruit cadencé que faisaient
                         leurs pieds, s'approchait <del>sourd et</del><gap unit="word" quantity="1"
-                           rend="strikethrough"/>
+                           rend="strikethrough" reason="deleted"/>
                         <add unit="word" quantity="3" rend="align(margin)">sinistre comme
                            une</add><add unit="word" quantity="2" rend="align(above)">danse
                            macabre</add> L'ange Paméla ne s'en souciait pas. <del unit="word"
@@ -1243,8 +1243,8 @@
                         destiné dans ma bouche à glorifier <add unit="word" quantity="1"
                            rend="align(margin)">légitimement</add> nos Etats-Unis devait paraître
                         (elle était là une plaisanterie mortuaire que je trouvai excellente) <gap
-                           unit="word" quantity="1" rend="strikethrough"/> aux soldats <del
-                           unit="word" quantity="2" rend="strikethrough">qui voulai</del>
+                           unit="word" quantity="1" rend="strikethrough" reason="deleted"/> aux
+                        soldats <del unit="word" quantity="2" rend="strikethrough">qui voulai</del>
                         <add unit="word" quantity="1" rend="align(margin)">qui</add> allaient
                         devenir mes bourreaux, une <gap unit="word" quantity="1" reason="deleted"/>
                         apologie <add unit="word" quantity="2" rend="highlighted">in

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_all.rng" type="application/xml"
 	schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
 <?xml-model href="out/poeme_ODD.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
    <teiHeader>
@@ -1265,7 +1266,7 @@
                         facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f73.item.r=Manuscrit%20Apollinaire"/>
                      <p><add rend="align(top)">22</add></p>          
                      <lg type="huitain" n="3">
-                        <delSpan spanTo="#p_22" unit="line" quantity="28" rend="strikethrough"/>
+                        <delSpan spanTo="#p_22a" unit="line" quantity="28" rend="strikethrough"/>
                         <l>Que je m'ennuie entre ces quatre murs tous nus</l>
                         <l><del unit="word" quantity="3" rend="strikethrough">Où se mêlent</del> Et
                            peints de couleurs pâles</l>
@@ -1293,18 +1294,14 @@
                      </lg>
 
                      <lg type="quatrain" n="1">
-                        <l><subst>
-                              <del unit="line" quantity="1" rend="strikethrough">Prends en pitié
-                                    le<del unit="char" quantity="1" rend="strikethrough">s</del>
-                                    coeur<del unit="char" quantity="1" rend="strikethrough">s</del>
-                                 de qui veut bien m'aimer</del>
-                              <del unit="line" quantity="1" rend="strikethrough">Et puis que ceux
-                                 qui souffrent</del>
-                              <del unit="line" quantity="1" rend="strikethrough">Accuse de moi
-                                 seul</del>
-                              <add rend="align(below)">Et tous ces pauvres coeurs battant dans la
-                                 prison</add>
-                           </subst></l>
+                        <delSpan spanTo="#p_22b" unit="line" quantity="3" rend="strikethrough"/>
+                        <l>Mais les couloirs où crie</l>
+                           <l>Dans les couloirs</l>
+                        <l>Cette chaise illisible où je m'assieds</l>
+                           <anchor xml:id="p_22b"/>
+                        <l><add xml:id="a1" rend="align(below)">Que deviendrai-je ? ô Dieu qui connais ma
+                           douleur</add></l>
+                        <substJoin target="#p_22b #a1"/>
                         <l>L'amour qui m'acccompagne</l>
                         <l>Prends en pitié surtout ma débile raison</l>
                         <figure rend="align(margin)">
@@ -1327,11 +1324,11 @@
                         <l>Comme aux beaux jours de mon enfance</l>
                         <l><subst>
                               <del unit="line" quantity="1" rend="strikethrough">et bien plus
-                                 fermement:barré)</del>
+                                 fermement</del>
                               <add rend="align(below)">Seigneur ! Agrées mes louanges</add>
                            </subst></l>
                         <l>Je crois en vous, je crois, je crois.</l>
-                        <anchor xml:id="p_22"/>
+                        <anchor xml:id="p_22a"/>
                      </lg>
                   </div>
                </div>
@@ -1395,20 +1392,21 @@
                   <div type="page" n="23">
                      <pb type="recto"
                         facs="https://gallica.bnf.fr/ark:/12148/btv1b52505641f/f73.item.r=Manuscrit%20Apollinaire"/>
-                     <p><add rend="align(top)">23</add></p>
+                     <p><add rend="align(top)">23</add></p>                     
                      <lg type="quatrain" n="3">
-                        <delSpan spanTo="#p_23" unit="line" quantity="28" rend="strikethrough"/>
-                        <l><subst>
-                              <del unit="line" quantity="1" rend="strikethrough">Vierge plus douce
-                                 que le sucre</del>
-                              <del unit="line" quantity="1" rend="strikethrough">Vierge qui m'avez
-                                 protégé</del>
-                              <add rend="align(below)">Et Je viens de dire un <subst>
+                        <delSpan spanTo="#p_23a" unit="line" quantity="28" rend="strikethrough"/>
+                        <delSpan spanTo="#p_23b" unit="line" quantity="2" rend="strikethrough"/>
+                           <l>Vierge plus douce                           
+                              que le sucre</l>
+                           <l>Vierge qui m'avez
+                                 protégé</l>
+                           <anchor xml:id="p_23b"/>
+                              <l><add xml:id="a2" rend="align(below)">Et Je viens de dire un <subst>
                                     <del unit="word" quantity="1" rend="strikethrough"
                                        >chapelet</del>
                                     <add rend="overtyped">rosaire</add>
                                  </subst></add>
-                           </subst></l>
+                                 <substJoin target="#p_23b #a2"/></l>
                         <l>Avec mes doigts pour chapelet</l>
                         <l>O Vierge Sainte écoutez les</l>
                         <figure rend="align(margin)">
@@ -1484,7 +1482,7 @@
                                  tu ne meures</del>
                               <add rend="align(below)">comme passent toutes les heures</add>
                            </subst></l>
-                        <anchor xml:id="p_23"/>
+                        <anchor xml:id="p_23a"/>
                      </lg>
                   </div>
                </div>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/Encodage_complet_Recueil.xml
@@ -165,7 +165,7 @@
                      <lg type="tercet" n="3">
                         <l>L'amour s'en <subst>
                               <del unit="word" quantity="2" rend="overtyped">est allé</del>
-                              <add>va</add>
+                              <add unit="word" quantity="1" rend="overtyped">va</add>
                            </subst></l>
                         <l>L'amour s'en va; comme la vie est lente</l>
                         <l>Et comme l'espérance est violente!</l>
@@ -315,15 +315,17 @@
                               <del quantity="6" unit="word" rend="overtyped">Connu d’Amour de cette
                                     sor<unclear unit="char" quantity="2" reason="illegible"
                                     >te</unclear></del>
-                              <add> vu, couché dans les feuilles m<unclear unit="char" quantity="4"
-                                    reason="illegible">ortes</unclear></add>
+                              <add quantity="5" unit="word" rend="overtyped"> vu, couché dans les
+                                 feuilles m<unclear unit="char" quantity="4" reason="illegible"
+                                    >ortes</unclear></add>
                            </subst></l>
                         <l><subst>
                               <del quantity="4" unit="word" rend="overtyped">D’Amour aime jusqu’au
                                     t<unclear unit="char" quantity="4" reason="illegible"
                                     >répas</unclear></del>
-                              <add>Mon <del quantity="1" unit="word" rend="strikethrough"
-                                    >pauvre</del> Amour après son trépas</add>
+                              <add quantity="6" unit="word" rend="align(below)">Mon <del
+                                    quantity="1" unit="word" rend="strikethrough">pauvre</del> Amour
+                                 après son trépas</add>
                            </subst></l>
                         <l>
                            <del><gap quantity="1" unit="word" reason="illegible"/></del> coeurs
@@ -388,7 +390,7 @@
                         <l>Moi, qui sais des lais pour les reines,</l>
                         <l><subst>
                               <del quantity="1" unit="char" rend="overtyped">D</del>
-                              <add>L</add>
+                              <add quantity="1" unit="char" rend="overtyped">L</add>
                            </subst>es complaintes de mes années,</l>
                         <l>Des hymnes d’esclave aux murènes,</l>
                         <l>La romance du mal-aimé</l>
@@ -494,7 +496,7 @@
                         <l>Mon île au loin, ma Désirade</l>
                         <l><subst>
                               <del quantity="1" unit="word" rend="overtyped">Mon</del>
-                              <add>Ma</add>
+                              <add quantity="1" unit="word" rend="overtyped">Ma</add>
                            </subst> rose, mon giroflier…</l>
                      </lg>
                      <lg type="quintil" n="29">
@@ -528,7 +530,7 @@
                      <lg type="quintil" n="32">
                         <l>Et toi qui me suis en rampan<subst>
                               <del quantity="1" unit="char" rend="overtyped">s</del>
-                              <add>t</add>
+                              <add quantity="1" unit="char" rend="overtyped">t</add>
                            </subst></l>
                         <l>Dieu de mes dieux morts en automne</l>
                         <l>Tu mesures combien d’empans</l>
@@ -649,9 +651,10 @@
                         <l>Quel chevalier es-tu là bas ?</l>
                         <l><subst>
                               <del><gap quantity="1" unit="word" reason="illegible"/></del>
-                              <add rend="align(above)"><del rend="overtyped"><gap quantity="1"
-                                       unit="word" reason="illegible"/></del></add>
-                              <add>Sultan</add>
+                              <add quantity="1" unit="word" rend="align(above)"><del
+                                    rend="overtyped"><gap quantity="1" unit="word"
+                                       reason="illegible"/></del></add>
+                              <add quantity="1" unit="word" rend="overtyped">Sultan</add>
                            </subst> de Turcs puants qui manges</l>
                         <l>Ce que Satan chie aux sabbats</l>
                      </lg>
@@ -671,7 +674,7 @@
                         <l>Poisson <subst>
                               <del rend="overtyped"><gap quantity="1" unit="word" reason="illegible"
                                  /></del>
-                           <add quantity="1" unit="word" rend="overtyped">pourri</add>
+                              <add quantity="1" unit="word" rend="overtyped">pourri</add>
                            </subst> de Salonique,</l>
                         <l>Gemmes de cabochons affreux</l>
                         <l>Des yeux creuvés à coup de piques</l>
@@ -691,7 +694,7 @@
                         <l>Tes richesses garde<del rend="strikethrough">nt</del> les toutes</l>
                         <l>Pour payer <subst>
                               <del quantity="1" unit="char" rend="overtyped">d</del>
-                              <add>t</add>
+                              <add quantity="1" unit="char" rend="overtyped">t</add>
                            </subst>es médicaments.</l>
                      </lg>
                      <lg type="tercet" n="2">

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/out/poeme_ODD.rng
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/out/poeme_ODD.rng
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0"
-         xmlns:xlink="http://www.w3.org/1999/xlink"
+<grammar xmlns:xlink="http://www.w3.org/1999/xlink"
          xmlns:tei="http://www.tei-c.org/ns/1.0"
          xmlns:teix="http://www.tei-c.org/ns/Examples"
+         xmlns="http://relaxng.org/ns/structure/1.0"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2021-02-28T08:24:28Z. .
-TEI Edition: Version 3.6.0. Last updated on
-	16th July 2019, revision daa3cc0b9
-TEI Edition Location: http://www.tei-c.org/Vault/P5/Version 3.6.0/
+Schema generated from ODD source 2021-03-01T17:13:11Z. .
+TEI Edition: Version 4.1.0. Last updated on
+	19th August 2020, revision b414ba550
+TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.1.0/
   
 --><!---->
    <define name="macro.paraContent">
@@ -38,8 +38,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5/Version 3.6.0/
          <choice>
             <text/>
             <ref name="model.gLike"/>
-            <ref name="model.qLike"/>
+            <ref name="model.attributable"/>
             <ref name="model.phrase"/>
+            <ref name="model.global"/>
+         </choice>
+      </zeroOrMore>
+   </define>
+   <define name="macro.phraseSeq.limited">
+      <zeroOrMore>
+         <choice>
+            <text/>
+            <ref name="model.limitedPhrase"/>
             <ref name="model.global"/>
          </choice>
       </zeroOrMore>
@@ -172,7 +181,7 @@ Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inche
                <value>char</value>
                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(characters) characters of text</a:documentation>
                <data type="token">
-                  <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                  <param name="pattern">[^\p{C}\p{Z}]+</param>
                </data>
             </choice>
          </attribute>
@@ -211,7 +220,7 @@ Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inche
          <attribute name="break">
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">indicates whether or not the element bearing this attribute should be considered to mark the end of an orthographic token in the same way as whitespace.</a:documentation>
             <data type="token">
-               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               <param name="pattern">[^\p{C}\p{Z}]+</param>
             </data>
          </attribute>
       </optional>
@@ -239,31 +248,34 @@ Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inche
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
             id="oddbyexample-att.datable.w3c-att-datable-w3c-when-constraint-rule-1">
       <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns="http://www.tei-c.org/ns/1.0"
                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
                 context="tei:*[@when]">
-        <sch:report test="@notBefore|@notAfter|@from|@to" role="nonfatal">The @when attribute cannot be used with any other att.datable.w3c attributes.</sch:report>
+         <sch:report test="@notBefore|@notAfter|@from|@to" role="nonfatal">The @when attribute cannot be used with any other att.datable.w3c attributes.</sch:report>
       </sch:rule>
    </pattern>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
             id="oddbyexample-att.datable.w3c-att-datable-w3c-from-constraint-rule-2">
       <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns="http://www.tei-c.org/ns/1.0"
                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
                 context="tei:*[@from]">
-        <sch:report test="@notBefore" role="nonfatal">The @from and @notBefore attributes cannot be used together.</sch:report>
+         <sch:report test="@notBefore" role="nonfatal">The @from and @notBefore attributes cannot be used together.</sch:report>
       </sch:rule>
    </pattern>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
             id="oddbyexample-att.datable.w3c-att-datable-w3c-to-constraint-rule-3">
       <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns="http://www.tei-c.org/ns/1.0"
                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
                 context="tei:*[@to]">
-        <sch:report test="@notAfter" role="nonfatal">The @to and @notAfter attributes cannot be used together.</sch:report>
+         <sch:report test="@notAfter" role="nonfatal">The @to and @notAfter attributes cannot be used together.</sch:report>
       </sch:rule>
    </pattern>
    <define name="att.datable.attributes">
@@ -395,7 +407,7 @@ Suggested values include: 1] cm (centimetres); 2] mm (millimetres); 3] in (inche
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -518,7 +530,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
                      <value>inspace</value>
                      <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in a predefined space, for example left by an earlier scribe.</a:documentation>
                      <data type="token">
-                        <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                        <param name="pattern">[^\p{C}\p{Z}]+</param>
                      </data>
                   </choice>
                </oneOrMore>
@@ -529,11 +541,12 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
             id="oddbyexample-att.typed-subtypeTyped-constraint-rule-4">
       <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns="http://www.tei-c.org/ns/1.0"
                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
                 context="tei:*[@subtype]">
-        <sch:assert test="@type">The <sch:name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</sch:assert>
+         <sch:assert test="@type">The <sch:name/> element should not be categorized in detail with @subtype unless also categorized in general with @type</sch:assert>
       </sch:rule>
    </pattern>
    <define name="att.pointing.attributes">
@@ -559,12 +572,13 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
             id="oddbyexample-att.pointing-targetLang-targetLang-constraint-rule-5">
       <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns="http://www.tei-c.org/ns/1.0"
                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
                 context="tei:*[not(self::tei:schemaSpec)][@targetLang]">
-            <sch:assert test="@target">@targetLang should only be used on <sch:name/> if @target is specified.</sch:assert>
-          </sch:rule>
+         <sch:assert test="@target">@targetLang should only be used on <sch:name/> if @target is specified.</sch:assert>
+      </sch:rule>
    </pattern>
    <define name="att.pointing.attribute.target">
       <optional>
@@ -601,7 +615,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
          <attribute name="sortKey">
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">supplies the sort key for this element in an index, list or group which contains it.</a:documentation>
             <data type="token">
-               <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+               <param name="pattern">[^\p{C}\p{Z}]+</param>
             </data>
          </attribute>
       </optional>
@@ -617,7 +631,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -650,14 +664,15 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
             id="oddbyexample-att.spanning-spanTo-spanTo-2-constraint-rule-6">
       <sch:rule xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:xi="http://www.w3.org/2001/XInclude"
                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
                 xmlns="http://www.tei-c.org/ns/1.0"
                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
                 context="tei:*[@spanTo]">
-            <sch:assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]">
+         <sch:assert test="id(substring(@spanTo,2)) and following::*[@xml:id=substring(current()/@spanTo,2)]">
 The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow the current element <sch:name/>
-                  </sch:assert>
-          </sch:rule>
+         </sch:assert>
+      </sch:rule>
    </pattern>
    <define name="att.timed.attributes">
       <empty/>
@@ -955,7 +970,9 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
       <notAllowed/>
    </define>
    <define name="model.global.meta">
-      <notAllowed/>
+      <choice>
+         <ref name="substJoin"/>
+      </choice>
    </define>
    <define name="model.milestoneLike">
       <choice>
@@ -1135,7 +1152,7 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
    <define name="model.quoteLike_sequenceRepeatable">
       <notAllowed/>
    </define>
-   <define name="model.qLike">
+   <define name="model.attributable">
       <choice>
          <ref name="model.quoteLike"/>
       </choice>
@@ -1314,7 +1331,7 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
          <ref name="model.labelLike"/>
          <ref name="model.listLike"/>
          <ref name="model.stageLike"/>
-         <ref name="model.qLike"/>
+         <ref name="model.attributable"/>
       </choice>
    </define>
    <define name="model.phrase">
@@ -1364,7 +1381,7 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
          <ref name="creation"/>
       </choice>
    </define>
-   <define name="model.resourceLike">
+   <define name="model.resource">
       <choice>
          <ref name="text"/>
       </choice>
@@ -1412,6 +1429,10 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
                <a:documentation>specifies whether or not its parent element is fragmented in some way, typically by some other overlapping structure: for example a speech which is divided between two or more verse stanzas, a paragraph which is split across a page division, a verse line which is divided between two speakers.</a:documentation>
                <choice>
                   <value>N</value>
+                  <a:documentation/>
+                  <value>I</value>
+                  <a:documentation/>
+                  <value>F</value>
                   <a:documentation/>
                </choice>
             </attribute>
@@ -1539,23 +1560,29 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
                         <value>align(beside)</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(right)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
                         <value>align(top)</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(margin)</value>
+                        <value>align(left)</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(below)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>surrounded</value>
+                        <value>align(right)</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
                         <value>align(top-right)</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
                         <value>align(top-left)</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>highlighted</value>
+                        <value>align(margin)</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>align(margin-left)</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>align(margin-right)</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>align(below)</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>surrounded</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
                         <value>overtyped</value>
+                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                        <value>highlighted</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
                      </choice>
                   </oneOrMore>
@@ -2127,7 +2154,7 @@ Elements]</a:documentation>
    </define>
    <define name="msDesc">
       <element name="msDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript description) contains a description of a single identifiable manuscript or other text-bearing object. [10.1. Overview]</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(manuscript description) contains a description of a single identifiable manuscript or other text-bearing object such as early printed books. [10.1. Overview]</a:documentation>
          <group>
             <ref name="msIdentifier"/>
             <zeroOrMore>
@@ -2190,19 +2217,9 @@ Elements]</a:documentation>
                <report xmlns:s="http://purl.oclc.org/dsdl/schematron" test="count(tei:width)&gt; 1">
 The element <name/> may appear once only
       </report>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="oddbyexample-dimensions-duplicateDim-constraint-report-9">
-            <rule context="tei:dimensions">
                <report xmlns:s="http://purl.oclc.org/dsdl/schematron" test="count(tei:height)&gt; 1">
 The element <name/> may appear once only
       </report>
-            </rule>
-         </pattern>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="oddbyexample-dimensions-duplicateDim-constraint-report-10">
-            <rule context="tei:dimensions">
                <report xmlns:s="http://purl.oclc.org/dsdl/schematron" test="count(tei:depth)&gt; 1">
 The element <name/> may appear once only
       </report>
@@ -2401,7 +2418,7 @@ The element <name/> may appear once only
    <define name="institution">
       <element name="institution">
          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of an organization such as a university or library, with which a manuscript or other object is identified, generally its holding institution. [10.4. The Manuscript Identifier]</a:documentation>
-         <ref name="macro.xtext"/>
+         <ref name="macro.phraseSeq.limited"/>
          <ref name="att.global.attribute.xmlid"/>
          <ref name="att.global.attribute.n"/>
          <ref name="att.global.attribute.xmllang"/>
@@ -2420,7 +2437,7 @@ The element <name/> may appear once only
    <define name="repository">
       <element name="repository">
          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">contains the name of a repository within which manuscripts or other objects are stored, possibly forming part of an institution. [10.4. The Manuscript Identifier]</a:documentation>
-         <ref name="macro.xtext"/>
+         <ref name="macro.phraseSeq.limited"/>
          <ref name="att.global.attribute.xmlid"/>
          <ref name="att.global.attribute.n"/>
          <ref name="att.global.attribute.xmllang"/>
@@ -2782,7 +2799,7 @@ The element <name/> may appear once only
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -2796,7 +2813,7 @@ The element <name/> may appear once only
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -2810,7 +2827,7 @@ The element <name/> may appear once only
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -2824,7 +2841,7 @@ The element <name/> may appear once only
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -2838,7 +2855,7 @@ The element <name/> may appear once only
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -3040,7 +3057,7 @@ The element <name/> may appear once only
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                     <param name="pattern">[^\p{C}\p{Z}]+</param>
                   </data>
                </oneOrMore>
             </list>
@@ -3073,7 +3090,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
                         <value>inspace</value>
                         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">in a predefined space, for example left by an earlier scribe.</a:documentation>
                         <data type="token">
-                           <param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})+</param>
+                           <param name="pattern">[^\p{C}\p{Z}]+</param>
                         </data>
                      </choice>
                   </oneOrMore>
@@ -3272,7 +3289,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    </define>
    <define name="sourceDesc">
       <element name="sourceDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) describes the source from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) describes the source(s) from which an electronic text was derived or generated, typically a bibliographic description in the case of a digitized text, or a phrase such as "born digital" for a text which has no previous existence. [2.2.7. The Source Description]</a:documentation>
          <choice>
             <oneOrMore>
                <ref name="model.pLike"/>
@@ -3387,13 +3404,19 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
                   id="oddbyexample-delSpan-spanTo-constraint-assert-5">
             <rule context="tei:delSpan">
-               <assert xmlns:s="http://purl.oclc.org/dsdl/schematron" test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
+               <assert xmlns:xi="http://www.w3.org/2001/XInclude"
+                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                       test="@spanTo">The @spanTo attribute of <name/> is required.</assert>
             </rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
                   id="oddbyexample-delSpan-spanTo_fr-constraint-assert-6">
             <rule context="tei:delSpan">
-               <assert xmlns:s="http://purl.oclc.org/dsdl/schematron" test="@spanTo">L'attribut spanTo est requis.</assert>
+               <assert xmlns:xi="http://www.w3.org/2001/XInclude"
+                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                       test="@spanTo">L'attribut spanTo est requis.</assert>
             </rule>
          </pattern>
          <ref name="att.global.attribute.xmlid"/>
@@ -3442,7 +3465,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    </define>
    <define name="subst">
       <element name="subst">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution) groups one or more deletions with one or more additions when the combination is to be regarded as a single intervention in the text. [11.3.1.5. Substitutions]</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution) groups one or more deletions (or surplus text) with one or more additions when the combination is to be regarded as a single intervention in the text. [11.3.1.5. Substitutions]</a:documentation>
          <oneOrMore>
             <choice>
                <ref name="add"/>
@@ -3453,9 +3476,11 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
                   id="oddbyexample-subst-substContents1-constraint-assert-7">
             <rule context="tei:subst">
-               <assert xmlns:s="http://purl.oclc.org/dsdl/schematron"
-                       test="child::tei:add and child::tei:del">
-                  <name/> must have at least one child add and at least one child del</assert>
+               <assert xmlns:xi="http://www.w3.org/2001/XInclude"
+                       xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                       xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                       test="child::tei:add and (child::tei:del or child::tei:surplus)">
+                  <name/> must have at least one child add and at least one child del or surplus</assert>
             </rule>
          </pattern>
          <ref name="att.global.attribute.xmlid"/>
@@ -3491,6 +3516,58 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
          <empty/>
       </element>
    </define>
+   <define name="substJoin">
+      <element name="substJoin">
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution join) identifies a series of possibly fragmented additions, deletions, or other revisions on a manuscript that combine to make up a single intervention in the text [11.3.1.5. Substitutions]</a:documentation>
+         <zeroOrMore>
+            <choice>
+               <ref name="model.descLike"/>
+               <ref name="model.certLike"/>
+            </choice>
+         </zeroOrMore>
+         <ref name="att.global.attribute.xmlid"/>
+         <ref name="att.global.attribute.n"/>
+         <ref name="att.global.attribute.xmllang"/>
+         <ref name="att.global.attribute.xmlbase"/>
+         <ref name="att.global.attribute.xmlspace"/>
+         <ref name="att.global.rendition.attribute.rend"/>
+         <ref name="att.global.rendition.attribute.style"/>
+         <ref name="att.global.rendition.attribute.rendition"/>
+         <ref name="att.global.change.attribute.change"/>
+         <ref name="att.global.responsibility.attribute.cert"/>
+         <ref name="att.global.responsibility.attribute.resp"/>
+         <ref name="att.global.source.attribute.source"/>
+         <ref name="att.pointing.attribute.targetLang"/>
+         <ref name="att.pointing.attribute.evaluate"/>
+         <ref name="att.editLike.attribute.instant"/>
+         <ref name="att.written.attribute.hand"/>
+         <ref name="att.ranging.attribute.atLeast"/>
+         <ref name="att.ranging.attribute.atMost"/>
+         <ref name="att.ranging.attribute.min"/>
+         <ref name="att.ranging.attribute.max"/>
+         <ref name="att.ranging.attribute.confidence"/>
+         <attribute name="target">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">specifies the destination of the reference by supplying one or more URI References</a:documentation>
+            <list>
+               <oneOrMore>
+                  <data type="anyURI"/>
+               </oneOrMore>
+            </list>
+         </attribute>
+         <optional>
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="status"
+                       a:defaultValue="unremarkable">
+               <a:documentation>indicates the effect of the intervention, for example in the case of a deletion, strikeouts which include too much or too little text, or in the case of an addition, an insertion which duplicates some of the text already present.</a:documentation>
+               <choice>
+                  <value>unremarkable</value>
+                  <a:documentation/>
+               </choice>
+            </attribute>
+         </optional>
+         <empty/>
+      </element>
+   </define>
    <define name="anchor">
       <element name="anchor">
          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(anchor point) attaches an identifier to a point within a text, whether or not it corresponds with a textual element. [8.4.2. Synchronization and Overlap 16.5. Correspondence and Alignment]</a:documentation>
@@ -3512,22 +3589,41 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    </define>
    <define name="TEI">
       <element name="TEI">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI document) contains a single TEI-conformant document, combining a single TEI header with one or more members of the model.resourceLike class. Multiple <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> elements may be combined to form a <code xmlns="http://www.w3.org/1999/xhtml">&lt;teiCorpus&gt;</code> element. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(TEI document) contains a single TEI-conformant document, combining a single TEI header with one or more members of the model.resource class. Multiple <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> elements may be combined within a <code xmlns="http://www.w3.org/1999/xhtml">&lt;TEI&gt;</code> (or <code xmlns="http://www.w3.org/1999/xhtml">&lt;teiCorpus&gt;</code>) element. [4. Default Text Structure 15.1. Varieties of Composite Text]</a:documentation>
          <group>
             <ref name="teiHeader"/>
-            <oneOrMore>
-               <ref name="model.resourceLike"/>
-            </oneOrMore>
+            <choice>
+               <group>
+                  <oneOrMore>
+                     <ref name="model.resource"/>
+                  </oneOrMore>
+                  <zeroOrMore>
+                     <ref name="TEI"/>
+                  </zeroOrMore>
+               </group>
+               <oneOrMore>
+                  <ref name="TEI"/>
+               </oneOrMore>
+            </choice>
          </group>
-         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
-             prefix="tei"
-             uri="http://www.tei-c.org/ns/1.0"/>
-         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
-             prefix="xs"
-             uri="http://www.w3.org/2001/XMLSchema"/>
-         <ns xmlns="http://purl.oclc.org/dsdl/schematron"
-             prefix="rng"
-             uri="http://relaxng.org/ns/structure/1.0"/>
+         <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns="http://www.tei-c.org/ns/1.0"
+                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                 prefix="tei"
+                 uri="http://www.tei-c.org/ns/1.0"/>
+         <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns="http://www.tei-c.org/ns/1.0"
+                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                 prefix="xs"
+                 uri="http://www.w3.org/2001/XMLSchema"/>
+         <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                 xmlns:rng="http://relaxng.org/ns/structure/1.0"
+                 xmlns="http://www.tei-c.org/ns/1.0"
+                 xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                 prefix="rng"
+                 uri="http://relaxng.org/ns/structure/1.0"/>
          <ref name="att.global.attribute.xmlid"/>
          <ref name="att.global.attribute.n"/>
          <ref name="att.global.attribute.xmllang"/>
@@ -3580,7 +3676,9 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
             <zeroOrMore>
                <ref name="msDesc"/>
             </zeroOrMore>
-            <ref name="div"/>
+            <oneOrMore>
+               <ref name="div"/>
+            </oneOrMore>
          </group>
          <ref name="att.global.attribute.xmlid"/>
          <ref name="att.global.attribute.n"/>
@@ -3649,23 +3747,30 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
             </group>
          </choice>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="oddbyexample-div-divtypecorresp-constraint-rule-7">
+                  id="oddbyexample-div-typepoemeprose-constraint-rule-7">
             <s:rule xmlns="http://www.tei-c.org/ns/1.0"
                     xmlns:s="http://purl.oclc.org/dsdl/schematron"
                     context="tei:body/tei:div">
-                        <s:assert test="@type='poeme' and @corresp"> La première division doit être
-                           composée d'un attribut type de valeur poème et d'un attribut corresp
-                           associant le poème manuscrit à sa version éditée </s:assert>
-                     </s:rule>
+               <s:assert test="@type='poeme' or @type='prose'"> La première division doit être composée d'un attribut type de valeur poème ou de valeur prose
+                                </s:assert>
+            </s:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
                   id="oddbyexample-div-divtypen-constraint-rule-8">
             <s:rule xmlns="http://www.tei-c.org/ns/1.0"
                     xmlns:s="http://purl.oclc.org/dsdl/schematron"
                     context="tei:div/tei:div">
-                        <s:assert test="@type='page' and @n"> La première division doit être
-                           composée d'un attribut type de valeur page et d'un attribut n </s:assert>
-                     </s:rule>
+               <s:assert test="@type='page' and @n"> La première division doit être composée d'un attribut type de valeur page et d'un attribut n 
+                                </s:assert>
+            </s:rule>
+         </pattern>
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="oddbyexample-div-divcorresp-constraint-rule-9">
+            <s:rule xmlns="http://www.tei-c.org/ns/1.0"
+                    xmlns:s="http://purl.oclc.org/dsdl/schematron"
+                    context="tei:body/tei:div[@type='poeme']">
+               <s:assert test="@corresp">Une division ayant poeme comme valeur de l'attribut type doit également avoir un attribut corresp liant le poème à sa version éditée</s:assert>
+            </s:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
                   id="oddbyexample-div-abstractModel-structure-l-constraint-report-12">
@@ -3765,13 +3870,14 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
             </oneOrMore>
          </group>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-                  id="oddbyexample-docTitle-refReqdocTitle-constraint-rule-9">
+                  id="oddbyexample-docTitle-refReqdocTitle-constraint-rule-10">
             <s:rule xmlns="http://www.tei-c.org/ns/1.0"
                     xmlns:s="http://purl.oclc.org/dsdl/schematron"
                     context="tei:group//tei:docTitle">
-                        <s:assert test="@ref"> Il est obligatoire d'ajouter une référence à un
-                           poème. </s:assert>
-                     </s:rule>
+               <s:assert test="@ref"> Il est obligatoire
+                                    d'ajouter une référence à un poème.
+                                </s:assert>
+            </s:rule>
          </pattern>
          <ref name="att.global.attribute.xmlid"/>
          <ref name="att.global.attribute.n"/>
@@ -3811,8 +3917,6 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
                        a:defaultValue="main">
                <a:documentation>specifies the role of this subdivision of the title.</a:documentation>
                <choice>
-                  <value>main</value>
-                  <a:documentation/>
                   <value>main</value>
                   <a:documentation/>
                </choice>
@@ -3907,25 +4011,7 @@ Suggested values include: 1] below; 2] bottom; 3] margin; 4] top; 5] opposite; 6
    </define>
    <define name="att.lexicographic.attributes">
       <ref name="att.datcat.attributes"/>
-      <ref name="att.lexicographic.attribute.norm"/>
-      <ref name="att.lexicographic.attribute.orig"/>
       <ref name="att.lexicographic.attribute.opt"/>
-   </define>
-   <define name="att.lexicographic.attribute.norm">
-      <optional>
-         <attribute name="norm">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(normalized) gives a normalized form of information given by the source text in a non-normalized form</a:documentation>
-            <data type="string"/>
-         </attribute>
-      </optional>
-   </define>
-   <define name="att.lexicographic.attribute.orig">
-      <optional>
-         <attribute name="orig">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(original) gives the original string or is the empty string when the element does not appear in the source text.</a:documentation>
-            <data type="string"/>
-         </attribute>
-      </optional>
    </define>
    <define name="att.lexicographic.attribute.opt">
       <optional>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/out/poeme_ODD.rng
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/out/poeme_ODD.rng
@@ -5,7 +5,7 @@
          xmlns="http://relaxng.org/ns/structure/1.0"
          datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
          ns="http://www.tei-c.org/ns/1.0"><!--
-Schema generated from ODD source 2021-03-01T17:13:11Z. .
+Schema generated from ODD source 2021-03-01T17:58:05Z. .
 TEI Edition: Version 4.1.0. Last updated on
 	19th August 2020, revision b414ba550
 TEI Edition Location: https://www.tei-c.org/Vault/P5/Version 4.1.0/
@@ -1508,21 +1508,19 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
                <data type="decimal"/>
             </choice>
          </attribute>
-         <optional>
-            <attribute name="reason">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the reason for omission</a:documentation>
-               <list>
-                  <oneOrMore>
-                     <choice>
-                        <value>illegible</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>deleted</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                     </choice>
-                  </oneOrMore>
-               </list>
-            </attribute>
-         </optional>
+         <attribute name="reason">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">gives the reason for omission</a:documentation>
+            <list>
+               <oneOrMore>
+                  <choice>
+                     <value>illegible</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>deleted</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+               </oneOrMore>
+            </list>
+         </attribute>
          <empty/>
       </element>
    </define>
@@ -1550,45 +1548,43 @@ The element indicated by @spanTo (<sch:value-of select="@spanTo"/>) must follow 
          <ref name="att.ranging.attribute.min"/>
          <ref name="att.ranging.attribute.max"/>
          <ref name="att.ranging.attribute.confidence"/>
-         <optional>
-            <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rendition) indicates how the element in question was rendered or presented in the source text.</a:documentation>
-               <list>
-                  <oneOrMore>
-                     <choice>
-                        <value>align(above)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(beside)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(top)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(left)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(right)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(top-right)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(top-left)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(margin)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(margin-left)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(margin-right)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>align(below)</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>surrounded</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>overtyped</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                        <value>highlighted</value>
-                        <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
-                     </choice>
-                  </oneOrMore>
-               </list>
-            </attribute>
-         </optional>
+         <attribute name="rend">
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rendition) indicates how the element in question was rendered or presented in the source text.</a:documentation>
+            <list>
+               <oneOrMore>
+                  <choice>
+                     <value>align(above)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(beside)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(top)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(left)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(right)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(top-right)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(top-left)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(margin)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(margin-left)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(margin-right)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>align(below)</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>surrounded</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>overtyped</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                     <value>highlighted</value>
+                     <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
+                  </choice>
+               </oneOrMore>
+            </list>
+         </attribute>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
                        name="status"

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/poeme_ODD.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/poeme_ODD.xml
@@ -420,6 +420,7 @@
                         <valItem ident="align(below)"/>
                         <valItem ident="surrounded"/>
                         <valItem ident="overtyped"/>
+                        <valItem ident="highlighted"/>
                      </valList>
                         </attDef>
                         <attDef ident="type" mode="delete"/>
@@ -469,8 +470,6 @@
                         <attDef ident="agent" mode="delete"/>
                         <attDef ident="corresp" mode="delete"/>
                         <attDef ident="facs" mode="delete"/>
-                        <attDef ident="unit" mode="delete"/>
-                        <attDef ident="quantity" mode="delete"/>
                     </attList>
                 </elementSpec>
                 <elementSpec ident="name" mode="change">
@@ -828,10 +827,10 @@
                      </sequence>
                   </alternate>
                </content>
-                    <constraintSpec scheme="schematron" ident="divtypecorresp">
+                    <constraintSpec scheme="schematron" ident="typepoemeprose">
                         <constraint>
                             <s:rule context="tei:body/tei:div">
-                                <s:assert test="@type='poeme' and @corresp"> La première division doit être composée d'un attribut type de valeur poème et d'un attribut corresp associant le poème manuscrit à sa version éditée
+                                <s:assert test="@type='poeme' or @type='prose'"> La première division doit être composée d'un attribut type de valeur poème ou de valeur prose
                                 </s:assert>
                             </s:rule>
                         </constraint>
@@ -841,6 +840,13 @@
                             <s:rule context="tei:div/tei:div">
                                 <s:assert test="@type='page' and @n"> La première division doit être composée d'un attribut type de valeur page et d'un attribut n 
                                 </s:assert>
+                            </s:rule>
+                        </constraint>
+                    </constraintSpec>
+                    <constraintSpec scheme="schematron" ident="divcorresp">
+                        <constraint>
+                            <s:rule context="tei:body/tei:div[@type='poeme']">
+                                <s:assert test="@corresp">Une division ayant poeme comme valeur de l'attribut type doit également avoir un attribut corresp liant le poème à sa version éditée</s:assert>
                             </s:rule>
                         </constraint>
                     </constraintSpec>

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/poeme_ODD.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/poeme_ODD.xml
@@ -681,7 +681,7 @@
                 <!--Checking module verse-->
                 <!--Checking module transcr-->
                 <classRef key="att.global.facs"/>
-                <moduleRef key="transcr" include="delSpan subst"/>
+                <moduleRef key="transcr" include="delSpan subst substJoin"/>
                 <elementSpec ident="delSpan" mode="change">
                     <attList>
                         <attDef ident="corresp" mode="delete"/>
@@ -710,6 +710,20 @@
                         </attDef>
                         <attDef ident="unit" mode="delete"/>
                         <attDef ident="quantity" mode="delete"/>
+                    </attList>
+                </elementSpec>
+                <elementSpec ident="substJoin" mode="change">
+                    <attList>
+                        <attDef ident="corresp" mode="delete"/>
+                        <attDef ident="facs" mode="delete"/>
+                        <attDef ident="status" mode="change">
+                            <valList mode="add" type="closed">
+                                <valItem ident="unremarkable"/>
+                            </valList>
+                        </attDef>
+                        <attDef ident="unit" mode="delete"/>
+                        <attDef ident="quantity" mode="delete"/>
+                        <attDef ident="target" mode="change" usage="req"/>
                     </attList>
                 </elementSpec>
                 <!--Checking module linking-->

--- a/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/poeme_ODD.xml
+++ b/Recueil_poemes_encodes/Dossier_complet_xml_ODD_rng/poeme_ODD.xml
@@ -385,8 +385,8 @@
                                 <valItem ident="line"/>
                             </valList>
                         </attDef>                        
-                        <attDef ident="reason" mode="change">
-                            <valList mode="add" type="closed">
+                        <attDef ident="reason" mode="change" usage="req">
+                            <valList mode="add" type="closed" >
                                 <valItem ident="illegible"/>
                                 <valItem ident="deleted"/>
                             </valList>
@@ -405,7 +405,7 @@
                                 <valItem ident="unremarkable"/>
                             </valList>
                         </attDef>
-                        <attDef ident="rend" mode="change">
+                        <attDef ident="rend" mode="change" usage="req">
                             <valList mode="add" type="closed">
                         <valItem ident="align(above)"/>
                         <valItem ident="align(beside)"/>


### PR DESCRIPTION
Bonsoir!

Vous trouverez dans cette PR quelques ajouts et améliorations que je propose de faire sur notre encodage des poèmes manuscrits.

Dans un premier temps, j'ai rajouté deux substJoin qui ont disparu lors de la mise en commun des poèmes, et, ceux -ci étant les seuls de l'encodage, il m'a fallu l'ajouter à l'ODD.
J'ai profité de cette modification de l'ODD pour développer nos règles schématron sur nos div afin de séparer la règle concernant l'utilisation obligatoire des attributs type et corresp. Cela permet d'obtenir une première règle signalant qu'il faut mettre comme valeur de type soit poème soit prose et une autre règle qui force l'emploi d'un attribut corresp lorsque le type est égal à poème, ce qui donne ceci:
```
<constraintSpec scheme="schematron" ident="typepoemeprose">
                        <constraint>
                            <s:rule context="tei:body/tei:div">
                                <s:assert test="@type='poeme' or @type='prose'"> La première division 
doit être composée d'un attribut type de valeur poème ou de valeur prose
                                </s:assert>
                            </s:rule>
                      </constraint>
</constraintSpec>
<constraintSpec scheme="schematron" ident="divcorresp">
                        <constraint>
                            <s:rule context="tei:body/tei:div[@type='poeme']">
                                <s:assert test="@corresp">Une division ayant poeme comme valeur de 
l'attribut type doit également avoir un attribut corresp liant le poème à sa version éditée</s:assert>
                            </s:rule>
                        </constraint>
</constraintSpec>
```
Cette amélioration m'a indiqué quelques oublis dans l'encodage lors de sa réassociation au schéma, que j'ai corrigé. 

Enfin, j'étais un peu curieuse et ai voulu tester de remettre le stamp dans la balise institution, comme nous avions décidé de base dans l'issue #56 (ce qui n'était pas valide lors du travail fait pour associer l'ODD prototype à l'encodage final) et cela ne donne plus d'erreurs (je n'ai pas vraiment compris pourquoi...). Pensez-vous qu'il serait intéressant de le remettre ainsi afin de coller  aux choix faits précédemment?

N'hésitez pas à donner votre avis sur les éléments ajoutés ou proposer d'autres améliorations!