### PR TITLE
Proposition de documentation à structurer en xml et à transformer en HTML

### DIFF
--- a/Recueil_poemes_encodes/Documentation_Recueil_poemes.txt
+++ b/Recueil_poemes_encodes/Documentation_Recueil_poemes.txt
@@ -1,0 +1,23 @@
+﻿<div1>
+<head>Guide d’encodage pour le recueil des versions préparatoires de sept poèmes d’Alcools (Guillaume Apollinaire)<head>
+<p>Ce guide constitue une documentation ainsi qu’une aide à la structuration et à l’encodage des versions préparatoires du recueil poétique Alcools. L’objectif principal est l’exportation et l’enrichissement des données primaires de description des manuscrits, à des fins d’analyse génétique et interdisciplinaire du processus scriptural.<p>
+
+<div2>
+<head>Encoder les métadonnées du recueil</head>
+<p>Les métadonnées du recueil ont été encodées conformément aux règles et bonnes pratiques de la TEI. Ainsi, le <teiHeader> contient l’élément <fileDesc>, lequel regroupe les informations bibliographiques complètes de la source dans son double état – original et numérisé -, avec les mentions de responsabilité inhérentes à sa diffusion mais également à l’encodage. Un élément <sourceDesc> permet la description bibliographique approfondie de la source à partir de laquelle la numérisation a été produite. 
+Un élément msDesc contient les métadonnées archivistiques et matérielles du recueil, réparties dans les éléments enfants <msIdentifier>, <altIdentifier>, <msContents> et <physDesc>. Le premier et  le second regroupent les indications de lieu et de référencement -cote et identifiant ark , tandis que le troisième structure les informations inhérentes au contenu documentaire, à la foliotation (élément <locus>) et aux mentions de notes descriptives. Une indexation des manuscrits de chaque poème a été mise en place dans les éléments <msItemStruct> et ce, afin de respecter l’intégrité de la source encodée tout en allégeant les informations d’en-tête de chaque sous-ensemble décrit dans le <body> au moyen de pointeurs. 
+Un élément <physDesc> contient les éléments <objectDesc> et <bindingDesc> afin de décrire la forme physique du support et sa reliure. La description structurée de l’estampille, présente sur chaque manuscrit, figure de façon unique dans un élément <stamp> afin d’éviter une récurrence redondante des données. De plus, les dimensions de la source décrite sont contenues dans un élément <extent>.
+Enfin, les éléments relatifs à la langue et au cadre chronologique du processus d’écriture sont structurés dans <creation>.
+</p>
+
+<div2>
+<head>Restituer la genèse du processus d’écriture dans sa matérialité et sa plasticité</head>
+<p>
+Afin de respecter l’intégrité du recueil encodé - regroupement de plusieurs manuscrits distincts mais liés dans le même ensemble documentaire -, il nous est apparu indispensable d’utiliser l’élément <group>, lui même subdivisé en autant d’éléments <text> qu’il y a de sous- ensembles. L’ODD a été modifiée de façon à imposer son usage. Cette structure d’encodage permet notamment de mettre en relief cette « collection de sources » en répétant une arborescence relativement complète pour chaque poème et texte en prose. Ainsi, chaque élément <text> comprend :
+- un élément <front> qui regroupe les informations relatives aux titres et sous-titres (<docTitle> et <titlePart>). L’attribut @ref de <docTitle> permet de pointer vers les données indexées dans le teiHeader.
+- un élément <body> contenant un <msDesc> dédié à la description de la présentation matérielle générale du texte manuscrit. Les éléments enfants <supportDesc> et <layoutDesc> permettent de renseigner respectivement la taille approximative du texte ainsi que sa disposition en une ou plusieurs colonnes.
+Une imbrication d’éléments <div> permet ensuite de structurer et de typer chaque subdivision à l’aide des attributs @type et @n. Chaque poème ou texte en prose (La Femme Assise) fait l’objet d’un renvoi vers l’édition définitive avec l’url correspondante en valeur de l’attribut @correp. Un élément <pb> dont l’attribut @type prend pour valeur « recto » ou « verso » permet également le renvoi à la numérisation de la page encodée grâce à l’attribut @facs.
+
+Nous avons volontairement privilégié la description génétique de la source sur les données inhérentes à l’analyse littéraire. C’est pourquoi nous n’avons pas utilisé les éléments qu’offre la TEI pour l’encodage approfondi des informations métriques et prosodiques. Nous avons tout de même caractérisé et numéroté chaque strophe – structurée dans un <lg> - selon son type (distique, tercet, quatrain, etc.) afin de faciliter une exportation sélective de ces données. 
+Les ajouts, suppressions, corrections et substitutions ont été systématiquement encodés à l’aide des éléments <add>, <addSpan> (pour de longs extraits de texte), <del>, <delSpan>, <subst> et <substJoin>, et leurs attributs @unit, @quantity et @rend. 
+


### PR DESCRIPTION
Bonjour à tous,

Voici ma proposition de documentation pour l'encodage du recueil de sept poèmes d'_Alcools_. J'ai mis quelques balises de structuration générale pour la forme mais la structure xml avec les balises nécessaires à la transformation html restent à ajouter.
Il faudrait également ajouter quelques exemples en utilisant egxml (pour présenter un extrait encodé dans un "substJoin" par exemple) et préciser les réglages et contraintes appliqués à notre ODD.

Merci d'avance pour vos compléments, la structuration et la transformation html! :)